### PR TITLE
Move smart contract UI and execution into the package.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fileverse-dev/dsheet",
-  "version": "2.1.3-package-cleanup-2",
+  "version": "2.1.3-package-cleanup-3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fileverse-dev/dsheet",
-      "version": "2.1.3-package-cleanup-2",
+      "version": "2.1.3-package-cleanup-3",
       "dependencies": {
         "@fileverse-dev/dsheets-templates": "^0.0.29",
         "@fileverse-dev/formulajs": "^4.4.53",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "tailwindcss-animate": "^1.0.7",
         "tiny-emitter": "^2.1.0",
         "uuid": "^8.3.2",
+        "viem": "^2.35.0",
         "vite-plugin-dts": "^3.6.3",
         "xlsx": "^0.18.5",
         "xlsx-js-style": "^1.2.0",
@@ -3896,7 +3897,6 @@
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
       "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
@@ -3906,7 +3906,6 @@
       "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
       "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@noble/curves": "~1.9.0",
         "@noble/hashes": "~1.8.0",
@@ -3921,7 +3920,6 @@
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
       "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@noble/hashes": "1.8.0"
       },
@@ -3937,7 +3935,6 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -3950,7 +3947,6 @@
       "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
       "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@noble/hashes": "~1.8.0",
         "@scure/base": "~1.2.5"
@@ -3964,7 +3960,6 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -4628,7 +4623,6 @@
       "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
       "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/wevm"
       },
@@ -6836,7 +6830,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "ws": "*"
       }
@@ -7808,7 +7801,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@adraffy/ens-normalize": "^1.11.0",
         "@noble/ciphers": "^1.3.0",
@@ -7832,15 +7824,13 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
       "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ox/node_modules/@noble/ciphers": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -7853,7 +7843,6 @@
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
       "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@noble/hashes": "1.8.0"
       },
@@ -7869,7 +7858,6 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -7881,8 +7869,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -9642,7 +9629,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@noble/curves": "1.9.1",
         "@noble/hashes": "1.8.0",
@@ -9667,7 +9653,6 @@
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
       "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@noble/hashes": "1.8.0"
       },
@@ -9683,7 +9668,6 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -9696,7 +9680,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
       "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fileverse-dev/dsheet",
   "private": false,
   "description": "DSheet",
-  "version": "2.1.3-package-cleanup-2",
+  "version": "2.1.3-package-cleanup-3",
   "main": "dist/index.es.js",
   "module": "dist/index.es.js",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
     "xlsx-js-style": "^1.2.0",
     "y-indexeddb": "^9.0.12",
     "y-protocols": "^1.0.6",
-    "yjs": "^13.6.15"
+    "yjs": "^13.6.15",
+    "viem": "^2.35.0"
   },
   "devDependencies": {
     "@types/lodash": "^4.17.23",

--- a/src/editor/components/editor-workbook.tsx
+++ b/src/editor/components/editor-workbook.tsx
@@ -18,7 +18,6 @@ import { useEditor } from '../contexts/editor-context';
 import { useCollabAwareness } from '../hooks/use-collab-awareness';
 import {
   afterUpdateCell,
-  SmartContractQueryHandler,
 } from '../utils/after-update-cell';
 import { dataVerificationYdocUpdate } from '../utils/data-verification-ydoc-update';
 import { liveQueryListYdocUpdate } from '../utils/live-query-list-ydoc-update';
@@ -63,7 +62,6 @@ function readBooleanFromLocalStorage(key: string): boolean {
 }
 
 interface EditorWorkbookProps {
-  setShowSmartContractModal?: React.Dispatch<React.SetStateAction<boolean>>;
   setShowFetchURLModal?: React.Dispatch<React.SetStateAction<boolean>>;
   setFetchingURLData?: (fetching: boolean) => void;
   setInputFetchURLDataBlock?: React.Dispatch<React.SetStateAction<string>>;
@@ -79,7 +77,6 @@ interface EditorWorkbookProps {
   dsheetId: string;
   onDuneChartEmbed?: () => void;
   onSheetCountChange?: (sheetCount: number) => void;
-  handleSmartContractQuery?: SmartContractQueryHandler;
   sidebarActivePanel?: string | null;
   sidebarPortalRegistry?: SidebarPortalRegistryHandle | null;
   sidebarPortalRenderers?: Record<string, SidebarPortalRenderer>;
@@ -105,7 +102,6 @@ const EditorWorkbookComponent: React.FC<EditorWorkbookProps> = ({
   dsheetId,
   onDuneChartEmbed,
   onSheetCountChange,
-  handleSmartContractQuery,
   sidebarActivePanel = null,
   sidebarPortalRegistry = null,
   sidebarPortalRenderers = {},
@@ -113,7 +109,6 @@ const EditorWorkbookComponent: React.FC<EditorWorkbookProps> = ({
 }) => {
   const {
     setSelectedTemplate,
-    setShowSmartContractModal,
     sheetEditorRef,
     ydocRef,
     currentDataRef,
@@ -135,6 +130,7 @@ const EditorWorkbookComponent: React.FC<EditorWorkbookProps> = ({
     apiKeyStorage,
     openApiKeyModal,
     onDataBlockEvent,
+    smartContract,
   } = useEditor();
 
   const localUserEditRef = useRef(false);
@@ -364,7 +360,9 @@ const EditorWorkbookComponent: React.FC<EditorWorkbookProps> = ({
               : []
             : getCustomToolbarItems({
               handleContentPortal: handleOnChangePortalUpdate,
-              setShowSmartContractModal,
+              setShowSmartContractModal: smartContract.enabled
+                ? smartContract.setShowSmartContractModal
+                : undefined,
               getDocumentTitle,
               updateDocumentTitle,
               setExportDropdownOpen,
@@ -413,7 +411,7 @@ const EditorWorkbookComponent: React.FC<EditorWorkbookProps> = ({
               setInputFetchURLDataBlock,
               setDataBlockCalcFunction,
               dataBlockCalcFunction,
-              handleSmartContractQuery,
+              handleSmartContractQuery: smartContract.handleSmartContractQuery,
               handleLiveQueryData: handleLiveQuery,
               collabEnabled,
               collabIsOwner,

--- a/src/editor/components/smart-contract/error-toast.tsx
+++ b/src/editor/components/smart-contract/error-toast.tsx
@@ -1,0 +1,53 @@
+import { Button, LucideIcon } from '@fileverse/ui';
+import { SMART_CONTRACT_PANEL_ID } from '../../utils/smart-contract/constants';
+
+export const SmartContractReadingErrorToast = ({
+  smartContractReadingError,
+  setSmartContractReadingError,
+  openPanel,
+}: {
+  smartContractReadingError: {
+    hasError: boolean;
+    errorMessage: string;
+  };
+  setSmartContractReadingError: (error: {
+    hasError: boolean;
+    errorMessage: string;
+  }) => void;
+  openPanel: (panel: string) => void;
+}) => {
+  if (!smartContractReadingError.hasError) {
+    return null;
+  }
+
+  return (
+    <div className="fixed bottom-10 left-1/2 z-[9999] -translate-x-1/2 border color-border-danger bg-[#FFF1F2] rounded-lg py-2 px-3 flex items-center justify-between gap-1 lg:!gap-6 flex-col lg:!flex-row">
+      <div className="flex items-center gap-2">
+        <LucideIcon
+          name="TriangleAlert"
+          className="color-text-danger flex-shrink-0"
+          size="sm"
+        />
+        <p className="text-helper-text-sm lg:!text-[14px] color-text-danger font-normal">
+          {smartContractReadingError.errorMessage}. Please use imported
+          contract.
+        </p>
+      </div>
+
+      <Button
+        variant="danger"
+        size="sm"
+        className="!text-[12px] !py-2 !px-1 !min-w-fit !h-[24px] !rounded"
+        onClick={() => {
+          openPanel(SMART_CONTRACT_PANEL_ID);
+          setSmartContractReadingError({
+            hasError: false,
+            errorMessage: '',
+          });
+        }}
+      >
+        Open my contract
+      </Button>
+    </div>
+  );
+};

--- a/src/editor/components/smart-contract/index.css
+++ b/src/editor/components/smart-contract/index.css
@@ -1,0 +1,5 @@
+.accordin {
+    [role="region"] {
+        padding: 0px;
+    }
+}

--- a/src/editor/components/smart-contract/modal/abi-input-section.tsx
+++ b/src/editor/components/smart-contract/modal/abi-input-section.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+interface AbiInputSectionProps {
+  abiCode: string;
+  setAbiCode: (value: string) => void;
+  errorState: { message: string } | null;
+}
+
+export const AbiInputSection: React.FC<AbiInputSectionProps> = ({
+  abiCode,
+  setAbiCode,
+  errorState,
+}) => (
+  <>
+    <h1 className="mb-1 text-heading-xsm">Paste your ABI .json code</h1>
+
+    <textarea
+      value={abiCode}
+      onChange={(e) => setAbiCode(e.target.value)}
+      placeholder="ABI .json code"
+      className="w-full h-[100px] p-3 border  color-border-default color-text-secondary  rounded-lg text-body-text-sm resize-y focus:outline-none transition-colors"
+    />
+    {errorState?.message && (
+      <p className="color-text-danger text-helper-text-sm mt-1">
+        {errorState.message}
+      </p>
+    )}
+  </>
+);

--- a/src/editor/components/smart-contract/modal/contract-name-section.tsx
+++ b/src/editor/components/smart-contract/modal/contract-name-section.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { TextField, LucideIcon, Button } from '@fileverse/ui';
+import type { ContractConfig } from '../../../types/smart-contract';
+
+interface ContractNameSectionProps {
+  smartContractName: string;
+  setSmartContractName: (name: string) => void;
+  registryMap: Record<string, ContractConfig>;
+  abiCode: string;
+  isLoading: boolean;
+  onClickProceed: () => Promise<void>;
+}
+
+export const ContractNameSection: React.FC<ContractNameSectionProps> = ({
+  smartContractName,
+  setSmartContractName,
+  registryMap,
+  abiCode,
+  isLoading,
+  onClickProceed,
+}) => (
+  <div className="my-4 mx-3">
+    <p className="text-heading-xsm mb-1">Smart contract name</p>
+    <div className="w-full">
+      <TextField
+        isValid
+        placeholder="Name your smart contract to use it later"
+        className="w-[100%]"
+        onChange={(c) => {
+          setSmartContractName(c.target.value);
+        }}
+      />
+      {registryMap[smartContractName] && (
+        <p className="color-text-danger text-helper-text-sm mt-1">
+          Contract name already exists
+        </p>
+      )}
+    </div>
+    <div className="color-bg-secondary mt-2 rounded-lg p-3">
+      <div className="flex mb-1 gap-1 items-center">
+        <LucideIcon className="text-[#77818A] h-4 w-4" name={'Info'} />
+        <p className=" font-medium text-[12px] leading-[16px] font-size-2xsm  color-text-secondary">
+          Usage tip
+        </p>
+      </div>
+      <p className="text-helper-text-sm  color-text-secondary">
+        To use your newly added smart contract, you can invoke the onchain
+        function &quot;=SMARTCONTRACT&quot; on any cell.
+      </p>
+    </div>
+    <hr className="w-full color-border-default my-3" />
+    <Button
+      onClick={() => {
+        onClickProceed();
+      }}
+      size="md"
+      className="w-full"
+      disabled={
+        isLoading ||
+        !abiCode ||
+        !smartContractName ||
+        !!registryMap[smartContractName]
+      }
+    >
+      {isLoading && (
+        <LucideIcon
+          name={'LoaderCircle'}
+          className={'h-4 w-4 mr-3 animate-spin'}
+        />
+      )}
+      Save smart contract
+    </Button>
+  </div>
+);

--- a/src/editor/components/smart-contract/modal/file-upload-section.tsx
+++ b/src/editor/components/smart-contract/modal/file-upload-section.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { Button, LucideIcon, cn } from '@fileverse/ui';
+
+interface FileUploadSectionProps {
+  uploadedFile: any;
+  uploadProgress: number;
+  isUploading: boolean;
+  handleRemoveFile: () => void;
+  handleFileInputChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  fileInputRef: React.RefObject<HTMLInputElement>;
+}
+
+export const FileUploadSection: React.FC<FileUploadSectionProps> = ({
+  uploadedFile,
+  uploadProgress,
+  isUploading,
+  handleRemoveFile,
+  handleFileInputChange,
+  fileInputRef,
+}) => (
+  <div>
+    <h2 className="mb-2 text-heading-xsm">Upload ABI .json file</h2>
+    {!uploadedFile ? (
+      <div className={''}>
+        <input
+          ref={fileInputRef}
+          type="file"
+          className="hidden"
+          accept=".json,application/json"
+          onChange={handleFileInputChange}
+        />
+        <Button
+          onClick={() => {
+            fileInputRef.current?.click();
+          }}
+          className="flex gap-4 justify-center w-full"
+          variant={'secondary'}
+        >
+          <div className="flex items-center gap-3">
+            <LucideIcon name={'Upload'} />
+            <p>Upload</p>
+          </div>
+        </Button>
+      </div>
+    ) : (
+      <div className="flex items-center h-[64px] justify-between p-4 bg-gray-50 border border-gray-200 rounded-lg">
+        <div className="flex items-center space-x-3">
+          <LucideIcon
+            name="FileKey2"
+            size="md"
+            className={cn('color-icon-secondary')}
+          />
+          <div>
+            <h3 className="text-heading-xsm">{uploadedFile.name}</h3>
+            <p className="text-xs text-gray-500">{uploadedFile.size}</p>
+          </div>
+        </div>
+        {uploadProgress === 100 ? (
+          <div className="flex gap-4 items-center">
+            <div className="text-helper-text-sm color-bg-success-light w-[69px] p-2 rounded-md  color-text-success">
+              {' '}
+              Uploaded{' '}
+            </div>
+            <button
+              onClick={handleRemoveFile}
+              className="p-1 text-gray-400 hover:text-red-500 transition-colors"
+              disabled={isUploading}
+            >
+              <svg
+                className="w-4 h-4"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  d="M6 18L18 6M6 6l12 12"
+                ></path>
+              </svg>
+            </button>
+          </div>
+        ) : (
+          <div className="flex items-center space-x-4">
+            <div className="w-24 h-1 bg-gray-200 rounded-full overflow-hidden">
+              <div
+                className={`h-full rounded-full transition-all duration-300 ${
+                  uploadProgress === 100 ? 'bg-green-500' : 'bg-blue-500'
+                }`}
+                style={{ width: `${uploadProgress}%` }}
+              ></div>
+            </div>
+            {isUploading && (
+              <span className="text-xs text-gray-500">{uploadProgress}%</span>
+            )}
+            <button
+              onClick={handleRemoveFile}
+              className="p-1 text-gray-400 hover:text-red-500 transition-colors"
+              disabled={isUploading}
+            >
+              <svg
+                className="w-4 h-4"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="2"
+                  d="M6 18L18 6M6 6l12 12"
+                ></path>
+              </svg>
+            </button>
+          </div>
+        )}
+      </div>
+    )}
+    <hr className="w-full color-border-default my-4" />
+  </div>
+);

--- a/src/editor/components/smart-contract/modal/import-section.tsx
+++ b/src/editor/components/smart-contract/modal/import-section.tsx
@@ -1,0 +1,29 @@
+import { Button, LucideIcon } from '@fileverse/ui';
+import React from 'react';
+
+interface ImportSectionProps {
+  isImporting: boolean;
+  handleImport: () => void;
+}
+
+export const ImportSection: React.FC<ImportSectionProps> = ({
+  isImporting,
+  handleImport,
+}) => (
+  <div className="mb-4 mx-3">
+    <Button
+      onClick={handleImport}
+      size="md"
+      className="w-full"
+      disabled={isImporting}
+    >
+      {isImporting && (
+        <LucideIcon
+          name={'LoaderCircle'}
+          className={'h-4 w-4 mr-3 animate-spin'}
+        />
+      )}
+      Import Smart Contract
+    </Button>
+  </div>
+);

--- a/src/editor/components/smart-contract/modal/modal-header.tsx
+++ b/src/editor/components/smart-contract/modal/modal-header.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import {
+  LucideIcon,
+  TextField,
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+  cn,
+} from '@fileverse/ui';
+import { SupportedChain } from '../../../types/smart-contract';
+import { useMediaQuery } from 'usehooks-ts';
+
+interface ModalHeaderProps {
+  inputAddress: string;
+  setFormStep: (step: number) => void;
+  onAddressChange: (url: string) => void;
+  setSelectedChain: (chain: SupportedChain) => void;
+  networks: { label: string; value: SupportedChain }[];
+  selectedChain: SupportedChain;
+  showHint: boolean;
+}
+
+export const ModalHeader: React.FC<ModalHeaderProps> = ({
+  inputAddress,
+  setFormStep,
+  onAddressChange,
+  setSelectedChain,
+  selectedChain,
+  networks,
+  showHint,
+}) => {
+  const isMobile = useMediaQuery('(max-width: 700px)', {
+    defaultValue: true,
+  });
+  return (
+    <>
+      <div className="flex gap-2 items-center p-3  border-b h-[52px]">
+        <div className="flex">
+          <LucideIcon name="FileKey2" className={'w-[16.67px] h-[18.33px]'} />
+        </div>
+        <TextField
+          autoFocus
+          className={cn(
+            'border-none !p-0 text-body-sm focus:outline-none select-text disabled:opacity-100',
+            isMobile ? 'w-[170px]' : 'w-[331px]'
+          )}
+          placeholder="Enter a Contract address"
+          value={inputAddress}
+          onChange={(e) => {
+            setFormStep(1);
+            onAddressChange(e.target.value);
+          }}
+        />
+        <div className="h-[52px] border-l pl-3 flex items-center">
+          <Select
+            onValueChange={(value) => {
+              setSelectedChain(value as SupportedChain);
+            }}
+          >
+            <SelectTrigger
+              className="gap-3"
+              style={{ border: '0px', padding: '0px' }}
+            >
+              <SelectValue placeholder={selectedChain} />
+            </SelectTrigger>
+            <SelectContent>
+              {networks.map((network) => (
+                <SelectItem key={network.value} value={network.value}>
+                  <p className="text-body-text-sm">{network.label}</p>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+      {showHint && (
+        <p className="text-helper-text-sm color-text-secondary p-3">
+          <b>Hint:</b> Use =SMARTCONTRACT(&quot;contract_address&quot;,
+          &quot;chain&quot;) directly in a cell to call a smart contract on the
+          Gnosis, Ethereum, or Base chains.
+        </p>
+      )}
+    </>
+  );
+};

--- a/src/editor/components/smart-contract/smart-contract-list-item.tsx
+++ b/src/editor/components/smart-contract/smart-contract-list-item.tsx
@@ -1,0 +1,408 @@
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+  cn,
+  LucideIcon,
+} from '@fileverse/ui';
+import React, { useEffect, useState, useCallback, useMemo } from 'react';
+import type { Abi } from 'viem';
+import type { ContractConfig, ParsedFunction } from '../../types/smart-contract';
+import { parseAbiViewFunctions } from '../../utils/smart-contract/reading-utils';
+import {
+  parseFunctionSignature,
+  getFunctionWithArguments,
+} from '../../utils/smart-contract/signature-utils';
+
+// Extracted Components
+const CopyButton = ({ textToCopy }: { textToCopy: string }) => (
+  <div
+    className="w-6 h-6 flex justify-center items-center gap-3 p-2 rounded cursor-pointer active:bg-gray-300 active:scale-95"
+    onClick={() => navigator.clipboard.writeText(textToCopy)}
+  >
+    <div className="w-4 h-4">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="18"
+        height="18"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="lucide lucide-copy-icon lucide-copy"
+      >
+        <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
+        <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
+      </svg>
+    </div>
+  </div>
+);
+
+const CodeBlock = ({
+  children,
+  onCopy,
+}: {
+  children: React.ReactNode;
+  onCopy?: string;
+}) => (
+  <div className="flex justify-center items-center gap-2 self-stretch bg-[#f8f9fa] p-2 rounded border border-solid border-[#e8ebec]">
+    <code>
+      <span className="font-medium text-xs">{children}</span>
+    </code>
+    {onCopy && <CopyButton textToCopy={onCopy} />}
+  </div>
+);
+
+const SyntaxSection = () => (
+  <div className="flex flex-col gap-2 self-stretch">
+    <span className="font-medium text-xs text-[#77818a]">Syntax</span>
+    <CodeBlock onCopy="=SMARTCONTRACT('contract_name', 'function', 'argument')">
+      =SMARTCONTRACT(
+      <span className="text-[hsl(var(--color-text-success))]">
+        &quot;contract_name&quot;, &quot;function&quot;, &quot;argument&quot;
+      </span>
+      )
+    </CodeBlock>
+  </div>
+);
+
+const DescriptionItem = ({
+  label,
+  description,
+  isOptional = false,
+  link,
+}: {
+  label: string;
+  description: string;
+  isOptional?: boolean;
+  link?: { text: string; href: string };
+}) => (
+  <div className="flex flex-col justify-center gap-1 self-stretch py-1 rounded">
+    <p className="text-body-sm">
+      <code className="text-[hsl(var(--color-text-default)] font-mono text-sm font-bold leading-5">
+        {label}
+        {isOptional && (
+          <code className="!text-[hsl(var(--color-text-secondary))]">
+            {' '}
+            [optional]
+          </code>
+        )}
+        {': '}
+      </code>
+      {description}
+      {link && (
+        <>
+          {' See '}
+          <a
+            className="cursor-pointer text-[hsl(var(--color-text-link))]"
+            href={link.href}
+          >
+            {link.text}
+          </a>
+          {' section for more details.'}
+        </>
+      )}
+    </p>
+  </div>
+);
+
+const DescriptionSection = () => (
+  <div className="flex flex-col gap-2 self-stretch">
+    <span className="font-medium text-xs text-[#77818a]">Description</span>
+    <div className="flex flex-col gap-1 self-stretch">
+      <DescriptionItem
+        label="contract_name"
+        description="Name of the contract, given by import, you want to pull data for"
+      />
+      <DescriptionItem
+        label="functions"
+        description="Name of the function you want to call from the given contract."
+        link={{ text: 'Functions', href: '#function-list' }}
+      />
+      <DescriptionItem
+        label="argument"
+        description="Optional arguments to pass to the contract function"
+        isOptional
+      />
+    </div>
+  </div>
+);
+
+const ExampleCodeBlock = ({
+  contractName,
+  functionName,
+  args,
+}: {
+  contractName: string;
+  functionName?: string;
+  args?: string;
+}) => {
+  const copyText = `=SMARTCONTRACT("${contractName}", "${functionName}", ${args})`;
+
+  return (
+    <CodeBlock onCopy={copyText}>
+      =SMARTCONTRACT(
+      <span className="text-[hsl(var(--color-text-success))]">
+        &quot;{contractName}&quot;, &quot;{functionName}&quot;
+        {args ? `, ${args}` : ''}
+      </span>
+      )
+    </CodeBlock>
+  );
+};
+
+const FunctionExamples = ({
+  contractName,
+  functionContent,
+}: {
+  contractName: string;
+  functionContent: ParsedFunction[];
+}) => {
+  const functionDetail = useMemo(
+    () => getFunctionWithArguments(functionContent),
+    [functionContent]
+  );
+
+  const funParsed = useMemo(
+    () => parseFunctionSignature(functionDetail?.functionName || ''),
+    [functionDetail]
+  );
+
+  const cellRefArg = useMemo(
+    () =>
+      funParsed?.args
+        ?.split(',')
+        .map((_, index) => `A${index + 1}`)
+        .join(', '),
+    [funParsed]
+  );
+
+  if (!funParsed) return null;
+
+  return (
+    <>
+      <div className="mt-[4px] flex flex-col gap-[4px]">
+        <ExampleCodeBlock
+          contractName={contractName}
+          functionName={funParsed.name}
+          args={funParsed.args}
+        />
+        <div className="my-2">
+          <ExampleCodeBlock
+            contractName={contractName}
+            functionName={funParsed.name}
+            args={cellRefArg}
+          />
+        </div>
+      </div>
+      <p className="text-[hsl(var(--color-text-default, #363B3F))] font-normal text-[12px] leading-5 font-[`Helvetica_Neue`] mb-2">
+        Note: In above example {cellRefArg} is cell reference containing an
+        argument value.
+      </p>
+    </>
+  );
+};
+
+const FunctionList = ({
+  functionContent,
+  contractName,
+}: {
+  functionContent: ParsedFunction[];
+  contractName: string;
+}) => (
+  <>
+    <div className="flex flex-col justify-center gap-1 self-stretch py-2 rounded">
+      <span className="text-[hsl(var(--color-text-secondary,#77818A))] font-['Helvetica_Neue'] text-[12px] font-medium leading-[16px]">
+        Functions
+      </span>
+    </div>
+    {functionContent.map((data, index) => {
+      const functionDetail = parseFunctionSignature(data.functionName);
+      return (
+        <div key={index} className="w-full">
+          <div className="mb-2">
+            <code className="text-helper-mono text-[12px]">
+              <span className="font-medium text-xs">
+                =SMARTCONTRACT(
+                <span className="text-[hsl(var(--color-text-success))]">
+                  &quot;{contractName}&quot;, &quot;{functionDetail?.name}&quot;
+                  {functionDetail?.args ? ', ' + functionDetail.args : ''}
+                </span>
+                )
+              </span>
+            </code>
+          </div>
+          {index !== functionContent.length - 1 && (
+            <hr className="w-full my-2" />
+          )}
+        </div>
+      );
+    })}
+  </>
+);
+
+const FunctionsSection = ({
+  contractName,
+  functionContent,
+}: {
+  contractName: string;
+  functionContent: ParsedFunction[];
+}) => (
+  <Accordion className="!w-full" type="multiple" defaultValue={['function']}>
+    <AccordionItem value="function" className="border-none">
+      <AccordionTrigger
+        style={{ backgroundColor: 'white', background: 'white !important' }}
+        className="!p-0"
+        size="md"
+      >
+        <p className="text-heading-xsm">Functions and their arguments</p>
+      </AccordionTrigger>
+      <AccordionContent className="!pb-0" id="function-list">
+        <p className="text-[hsl(var(--color-text-default, #363B3F))] font-normal text-sm leading-5 font-[`Helvetica_Neue`] mb-2">
+          How to use functions and arguments? Place the function name followed
+          by its arguments. Explore examples below.
+        </p>
+        <FunctionExamples
+          contractName={contractName}
+          functionContent={functionContent}
+        />
+        <FunctionList
+          functionContent={functionContent}
+          contractName={contractName}
+        />
+      </AccordionContent>
+    </AccordionItem>
+  </Accordion>
+);
+
+const ContractHeader = ({
+  contractName,
+  onDelete,
+  isDeleting,
+}: {
+  contractName: string;
+  onDelete?: (name: string) => void;
+  isDeleting: boolean;
+}) => (
+  <div className="w-full flex justify-between h-[20px] items-center">
+    <div className="flex gap-2 items-center">
+      <div>
+        <LucideIcon
+          name="FileKey2"
+          size="sm"
+          className={cn('color-icon-secondary')}
+        />
+      </div>
+      <p className="text-heading-xsm flex-1 max-w-[200px] truncate">
+        {contractName}
+      </p>
+    </div>
+    {onDelete && (
+      <div
+        role="button"
+        onClick={() => onDelete(contractName)}
+        className="p-2 rounded-md hover:bg-[#FFF1F2] mr-[4px]"
+      >
+        <LucideIcon
+          name="Trash2"
+          size="sm"
+          stroke="#FB3449"
+          className={cn(
+            'cursor-pointer color-icon-danger',
+            isDeleting && 'cursor-not-allowed'
+          )}
+        />
+      </div>
+    )}
+  </div>
+);
+
+const ContractDetails = ({ contract }: { contract: ContractConfig }) => (
+  <div className="flex gap-4 items-center">
+    <div className="w-[46px]">
+      <p className="text-helper-text-sm color-text-secondary">Network</p>
+      <p className="text-helper-text-sm flex-1 truncate color-text-default">
+        {contract.network}
+      </p>
+    </div>
+    <div className="max-w-[222px]">
+      <p className="text-helper-text-sm color-text-secondary">Address</p>
+      <p className="truncate text-helper-text-sm flex-1 color-text-default">
+        {contract.address}
+      </p>
+    </div>
+  </div>
+);
+
+// Main Component
+export const SmartContractListItem = ({
+  contract,
+  onDelete,
+  fetchContractAbi,
+}: {
+  contract: ContractConfig;
+  onDelete?: (name: string) => void;
+  fetchContractAbi: (contract: ContractConfig) => Promise<Abi>;
+}) => {
+  const [isDeleting] = useState(false);
+  const [functionContent, setFunctionContent] = useState<ParsedFunction[]>([]);
+
+  const parseAbi = useCallback(async () => {
+    try {
+      const abi = await fetchContractAbi(contract);
+      const results = parseAbiViewFunctions(abi);
+      setFunctionContent(results);
+    } catch (error) {
+      console.error('Failed to fetch ABI for contract', contract.name, error);
+    }
+  }, [contract, fetchContractAbi]);
+
+  useEffect(() => {
+    parseAbi();
+  }, [parseAbi]);
+
+  return (
+    <div className="border px-3 py-[8px] w-full rounded-lg">
+      <div className="flex w-full justify-between items-center" />
+      <div className="w-full">
+        <div className="w-full mt-2">
+          <Accordion className="!w-full" collapsible type="single">
+            <AccordionItem value="item-1" className="border-none">
+              <AccordionTrigger
+                style={{
+                  backgroundColor: 'white',
+                  background: 'white !important',
+                }}
+                className="!p-0 mb-3"
+                size="md"
+              >
+                <ContractHeader
+                  contractName={contract.name}
+                  onDelete={onDelete}
+                  isDeleting={isDeleting}
+                />
+              </AccordionTrigger>
+              <AccordionContent className="!pb-4 !pt-0">
+                <div className="w-full">
+                  <div className="flex flex-col gap-4 self-stretch">
+                    <SyntaxSection />
+                    <DescriptionSection />
+                  </div>
+                  <hr className="w-full border-t border-dashed border-gray-200 mt-2 mb-4" />
+                  <FunctionsSection
+                    contractName={contract.name}
+                    functionContent={functionContent}
+                  />
+                </div>
+              </AccordionContent>
+            </AccordionItem>
+          </Accordion>
+        </div>
+      </div>
+      <ContractDetails contract={contract} />
+    </div>
+  );
+};

--- a/src/editor/components/smart-contract/smart-contract-modal-ui.tsx
+++ b/src/editor/components/smart-contract/smart-contract-modal-ui.tsx
@@ -1,0 +1,222 @@
+import React, { MutableRefObject, useState } from 'react';
+import { Button, LucideIcon } from '@fileverse/ui';
+import type { ContractConfig } from '../../types/smart-contract';
+import { SupportedChain } from '../../types/smart-contract';
+import {
+  fetchVerifiedAbi,
+  getChainFromChainId,
+} from '../../utils/smart-contract/reading-utils';
+import { Hex } from 'viem';
+
+import { ModalHeader } from './modal/modal-header';
+import { ImportSection } from './modal/import-section';
+import { AbiInputSection } from './modal/abi-input-section';
+import { FileUploadSection } from './modal/file-upload-section';
+import { ContractNameSection } from './modal/contract-name-section';
+import { useMediaQuery } from 'usehooks-ts';
+
+interface SmartContractModalUIProps {
+  abiCode: string;
+  smartContractName: string;
+  setSmartContractName: React.Dispatch<React.SetStateAction<string>>;
+  setAbiCode: React.Dispatch<React.SetStateAction<string>>;
+  uploadedFile: any;
+  setUploadedFile: React.Dispatch<React.SetStateAction<any>>;
+  uploadProgress: number;
+  isUploading: boolean;
+  handleRemoveFile: () => void;
+  handleUploadAreaClick: () => void;
+  handleFileInputChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  fileInputRef: React.RefObject<HTMLInputElement>;
+  selectedChain: SupportedChain;
+  setSelectedChain: React.Dispatch<React.SetStateAction<SupportedChain>>;
+  formStep: number;
+  setFormStep: React.Dispatch<React.SetStateAction<number>>;
+  onClickProceed: (abi?: any) => Promise<void>;
+  inputAddress: string;
+  isValidURL: boolean;
+  modalDivRef: React.RefObject<HTMLDivElement>;
+  onAddressChange: (url: string) => void;
+  isImportingRef: MutableRefObject<boolean>;
+  registryMapRef: MutableRefObject<Record<string, ContractConfig>>;
+  errorState: { message: string } | null;
+}
+
+export const SmartContractModalUI: React.FC<SmartContractModalUIProps> = ({
+  abiCode,
+  smartContractName,
+  setSmartContractName,
+  setAbiCode,
+  uploadedFile,
+  uploadProgress,
+  isUploading,
+  handleRemoveFile,
+  handleFileInputChange,
+  fileInputRef,
+  setSelectedChain,
+  formStep,
+  setFormStep,
+  selectedChain,
+  inputAddress,
+  isValidURL,
+  modalDivRef,
+  onAddressChange,
+  onClickProceed,
+  isImportingRef,
+  registryMapRef,
+  errorState,
+}) => {
+  const isDev = process.env.NEXT_PUBLIC_NETWORK_NAME === 'sepolia';
+  const networks = [
+    {
+      label: SupportedChain.Ethereum,
+      value: SupportedChain.Ethereum,
+    },
+    {
+      label: SupportedChain.Gnosis,
+      value: SupportedChain.Gnosis,
+    },
+    {
+      label: SupportedChain.Base,
+      value: SupportedChain.Base,
+    },
+  ];
+
+  isDev &&
+    networks.push({
+      label: SupportedChain.Sepolia,
+      value: SupportedChain.Sepolia,
+    });
+
+  const [isLoading, setIsLoading] = useState(false);
+  const [isImporting, setIsImporting] = useState(false);
+  const [isVerified, setIsVerified] = useState(true);
+
+  const handleImport = async () => {
+    setIsImporting(true);
+    const chain = getChainFromChainId(selectedChain);
+    isImportingRef.current = true;
+
+    const abi = await fetchVerifiedAbi(inputAddress as Hex, chain);
+    if (abi) {
+      setAbiCode(JSON.stringify(abi));
+      setIsImporting(false);
+      isImportingRef.current = false;
+      setFormStep(2);
+    } else {
+      isImportingRef.current = false;
+      setIsImporting(false);
+      setIsVerified(false);
+    }
+  };
+
+  const isMobile = useMediaQuery('(max-width: 700px)', {
+    defaultValue: true,
+  });
+
+  return (
+    <div
+      className="h-screen z-[9999] bg-gray-100 grid place-items-center relative"
+      ref={modalDivRef}
+    >
+      <div
+        className={`fixed top-1/4 left-1/2 ${isMobile ? 'max-w-[350px]' : 'w-[500px]'} transform -translate-x-1/2 rounded-xl fetch-url-modal bg-white !p-0 border-0 shadow-[0_8px_32px_0_rgba(0,0,0,0.15)]`}
+        style={{ transformOrigin: 'top center' }}
+      >
+        <div className="w-full">
+          {/* Header */}
+          <ModalHeader
+            inputAddress={inputAddress}
+            setFormStep={setFormStep}
+            onAddressChange={onAddressChange}
+            setSelectedChain={setSelectedChain}
+            networks={networks}
+            selectedChain={selectedChain}
+            showHint={isVerified && formStep === 1}
+          />
+
+          {/* Expandable Content */}
+          <div>
+            <div
+              className={`
+                ${isValidURL ? `${isVerified ? 'max-h-[300px]' : 'max-h-[400px]'}` : 'max-h-[0px]'}
+                transition-all ease-in-out duration-300 overflow-hidden
+              `}
+            >
+              {formStep === 1 ? (
+                <>
+                  {isVerified ? (
+                    <ImportSection
+                      isImporting={isImporting}
+                      handleImport={handleImport}
+                    />
+                  ) : (
+                    <div className="my-4 mx-3">
+                      <div>
+                        <AbiInputSection
+                          abiCode={abiCode}
+                          setAbiCode={setAbiCode}
+                          errorState={errorState}
+                        />
+
+                        {/* Divider */}
+                        <div className="relative my-4">
+                          <div className="absolute inset-0 flex items-center">
+                            <div className="w-full border-t border-gray-300"></div>
+                          </div>
+                          <div className="relative flex justify-center text-sm">
+                            <span className="px-4 bg-white text-gray-500">
+                              or
+                            </span>
+                          </div>
+                        </div>
+
+                        <FileUploadSection
+                          uploadedFile={uploadedFile}
+                          uploadProgress={uploadProgress}
+                          isUploading={isUploading}
+                          handleRemoveFile={handleRemoveFile}
+                          handleFileInputChange={handleFileInputChange}
+                          fileInputRef={fileInputRef}
+                        />
+                      </div>
+                      <Button
+                        onClick={() => {
+                          setFormStep(2);
+                        }}
+                        size="md"
+                        className="w-full"
+                        disabled={isLoading || !abiCode || !!errorState}
+                      >
+                        {isLoading && (
+                          <LucideIcon
+                            name={'LoaderCircle'}
+                            className={'h-4 w-4 mr-3 animate-spin'}
+                          />
+                        )}
+                        <p>Proceed</p>
+                      </Button>
+                    </div>
+                  )}
+                </>
+              ) : (
+                <ContractNameSection
+                  smartContractName={smartContractName}
+                  setSmartContractName={setSmartContractName}
+                  registryMap={registryMapRef.current}
+                  abiCode={abiCode}
+                  isLoading={isLoading}
+                  onClickProceed={async () => {
+                    setIsLoading(true);
+                    await onClickProceed();
+                    setIsLoading(false);
+                  }}
+                />
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/editor/components/smart-contract/smart-contract-modal.tsx
+++ b/src/editor/components/smart-contract/smart-contract-modal.tsx
@@ -1,0 +1,87 @@
+import React, { MutableRefObject } from 'react';
+import { SmartContractModalUI } from './smart-contract-modal-ui';
+import type { ContractConfig, SupportedChain } from '../../types/smart-contract';
+import { Hex } from 'viem';
+import { useSmartContractModal } from './use-smart-contract-modal';
+
+interface FetchUrlDataBlockProps {
+  showSmartContractModal: boolean;
+  setShowSmartContractModal: (show: boolean) => void;
+  onSaveContract: (
+    address: Hex,
+    chain: SupportedChain,
+    abi: string,
+    smartContractName: string
+  ) => Promise<void>;
+  registryMapRef: MutableRefObject<Record<string, ContractConfig>>;
+}
+
+export const SmartContractModal: React.FC<FetchUrlDataBlockProps> = ({
+  showSmartContractModal,
+  setShowSmartContractModal,
+  onSaveContract,
+  registryMapRef,
+}) => {
+  const {
+    inputAddress,
+    selectedChain,
+    setSelectedChain,
+    formStep,
+    setFormStep,
+    abiCode,
+    setAbiCode,
+    uploadedFile,
+    setUploadedFile,
+    uploadProgress,
+    isUploading,
+    fileInputRef,
+    smartContractName,
+    setSmartContractName,
+    isImportingRef,
+    modalDivRef,
+    handleFileInputChange,
+    handleUploadAreaClick,
+    handleRemoveFile,
+    handleAddressInputChange,
+    onClickProceed,
+    isValidAddress,
+    errorState,
+  } = useSmartContractModal({
+    onSaveContract,
+    setShowSmartContractModal,
+    registryMapRef,
+  });
+
+  return (
+    <div>
+      {showSmartContractModal && (
+        <SmartContractModalUI
+          abiCode={abiCode}
+          setAbiCode={setAbiCode}
+          uploadedFile={uploadedFile}
+          setUploadedFile={setUploadedFile}
+          uploadProgress={uploadProgress}
+          isUploading={isUploading}
+          handleRemoveFile={handleRemoveFile}
+          handleUploadAreaClick={handleUploadAreaClick}
+          handleFileInputChange={handleFileInputChange}
+          fileInputRef={fileInputRef}
+          formStep={formStep}
+          smartContractName={smartContractName}
+          setSmartContractName={setSmartContractName}
+          setFormStep={setFormStep}
+          selectedChain={selectedChain}
+          setSelectedChain={setSelectedChain}
+          inputAddress={inputAddress}
+          isValidURL={isValidAddress}
+          modalDivRef={modalDivRef}
+          onAddressChange={handleAddressInputChange}
+          onClickProceed={onClickProceed}
+          isImportingRef={isImportingRef}
+          registryMapRef={registryMapRef}
+          errorState={errorState}
+        />
+      )}
+    </div>
+  );
+};

--- a/src/editor/components/smart-contract/smart-contract-reading-intro.tsx
+++ b/src/editor/components/smart-contract/smart-contract-reading-intro.tsx
@@ -1,0 +1,87 @@
+import { Button, DynamicModal } from '@fileverse/ui';
+import { useEffect, useState } from 'react';
+import { useMediaQuery } from 'usehooks-ts';
+import { SMART_CONTRACT_PANEL_ID } from '../../utils/smart-contract/constants';
+
+const hasScQueryParam = () => {
+  if (typeof window === 'undefined') return false;
+  return new URLSearchParams(window.location.search).has('sc');
+};
+
+const removeScQueryParam = () => {
+  if (typeof window === 'undefined') return;
+  const url = new URL(window.location.href);
+  url.searchParams.delete('sc');
+  window.history.replaceState({}, '', url.toString());
+};
+
+export const SmartContractReadingIntro = ({
+  isAuthorized,
+  onOpenPanel,
+}: {
+  isAuthorized: boolean;
+  onOpenPanel: (panelId: string) => void;
+}) => {
+  const [isOpen, setIsOpen] = useState(hasScQueryParam());
+
+  useEffect(() => {
+    setIsOpen(hasScQueryParam());
+  }, []);
+
+  const tryItOut = () => {
+    setIsOpen(false);
+    if (isAuthorized) {
+      onOpenPanel(SMART_CONTRACT_PANEL_ID);
+      removeScQueryParam();
+    } else {
+      document.getElementById('triggerAuth')?.click();
+    }
+  };
+
+  const isMobile = useMediaQuery('(max-width: 1024px)', {
+    defaultValue: true,
+  });
+
+  return (
+    <DynamicModal
+      hasCloseIcon={true}
+      open={isOpen}
+      onOpenChange={(val) => {
+        setIsOpen(val);
+        if (!val) {
+          removeScQueryParam();
+        }
+      }}
+      className={`rounded-lg ${isMobile ? ' !w-full' : '!max-w-[394px]'}`}
+      contentClassName="rounded-lg"
+      content={
+        <div>
+          <div className="h-[296px] flex justify-center p-5 items-center bg-[#e8ebec] ">
+            <video
+              autoPlay={true}
+              muted={true}
+              playsInline={true}
+              loop={true}
+              src="https://s3.eu-west-2.amazonaws.com/assets.fileverse.io/dapp/public/assets/Area_V2.mp4"
+              className="w-full h-full object-cover"
+            />
+          </div>
+          <div className="px-5 pt-5 pb-2">
+            <h1 className="text-heading-xlg">Query smart contracts in cells</h1>
+            <p className="text-body-sm mt-3 color-text-secondary">
+              Turn smart contracts into real-time dashboards! You can add any
+              smart contract across chains, give it a name, and query its public
+              functions instantly using =SMARTCONTRACT(&quot;name&quot;,
+              &quot;function&quot;, inputs…).
+            </p>
+            <div className="flex justify-end mt-4">
+              <Button className="!max-w-[89px]" onClick={tryItOut}>
+                <p>Try it out</p>
+              </Button>
+            </div>
+          </div>
+        </div>
+      }
+    />
+  );
+};

--- a/src/editor/components/smart-contract/smart-contract-view-list.tsx
+++ b/src/editor/components/smart-contract/smart-contract-view-list.tsx
@@ -1,0 +1,588 @@
+import {
+  IconButton,
+  LucideIcon,
+  TextField,
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  TabsContent,
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+  Tooltip,
+} from '@fileverse/ui';
+import React, { useEffect, useState } from 'react';
+import { SmartContractListItem } from './smart-contract-list-item';
+import type {
+  ContractConfig,
+  SmartContractListViewProps,
+  MyContractsProps,
+  PopularContractsProps,
+  CodeBlockProps,
+  ParameterDescriptionProps,
+} from '../../types/smart-contract';
+import { POPULAR_CONTRACTS_MAP } from '../../utils/smart-contract/constants';
+import './index.css';
+
+// Constants
+const COPY_ICON_SVG = (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="18"
+    height="18"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className="lucide lucide-copy-icon lucide-copy"
+  >
+    <rect width="14" height="14" x="8" y="8" rx="2" ry="2" />
+    <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
+  </svg>
+);
+
+// Utility Components
+const CopyButton: React.FC<{ textToCopy: string }> = ({ textToCopy }) => {
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (copied) {
+      const timer = setTimeout(() => setCopied(false), 3000);
+      return () => clearTimeout(timer);
+    }
+  }, [copied]);
+
+  if (copied) {
+    return (
+      <div className="w-6 h-6 flex justify-center items-center gap-3 p-2 rounded cursor-pointer">
+        <Tooltip open={true} text="Copied" position={'bottom'}>
+          <LucideIcon name="Check" className="w-4 h-4" />
+        </Tooltip>
+      </div>
+    );
+  }
+  return (
+    <Tooltip text={'Copy'}>
+      <div
+        className="w-6 h-6 flex justify-center items-center gap-3 p-2 rounded cursor-pointer active:bg-gray-300 active:scale-95"
+        onClick={() => {
+          navigator.clipboard.writeText(textToCopy);
+          setCopied(true);
+        }}
+      >
+        <div className="w-4 h-4">{COPY_ICON_SVG}</div>
+      </div>
+    </Tooltip>
+  );
+};
+
+const CodeBlock: React.FC<CodeBlockProps> = ({
+  code,
+  copyText,
+}: CodeBlockProps) => (
+  <div className="flex justify-center items-center gap-2 self-stretch bg-[hsl(var(--color-bg-default))] p-2 rounded border border-solid border-[#e8ebec] mt-2">
+    <code className="break-all">
+      <span className="font-medium text-xs">{code}</span>
+    </code>
+    <CopyButton textToCopy={copyText} />
+  </div>
+);
+
+const ParameterDescription: React.FC<ParameterDescriptionProps> = ({
+  paramName,
+  description,
+  optional = false,
+}) => (
+  <div className="flex flex-col justify-center gap-1 self-stretch py-1 rounded">
+    <p className="text-body-sm">
+      <code className="text-[hsl(var(--color-text-default)] font-mono text-sm font-bold leading-5">
+        {paramName}
+        {optional && (
+          <code className="!text-[hsl(var(--color-text-secondary))]">
+            {' '}
+            [optional]
+          </code>
+        )}
+        {': '}
+      </code>
+      {description}
+    </p>
+  </div>
+);
+
+// Documentation Components
+const NonImportedContractDocs: React.FC = () => (
+  <Accordion
+    type="single"
+    collapsible
+    defaultValue="item-a"
+    className="w-full accordin"
+  >
+    <AccordionItem value="item-a" className="border-none">
+      <AccordionTrigger className="!pl-[0px] hover:!bg-[#f8f9fa] !text-left">
+        <span className="font-medium text-sm text-[#363b3f]">
+          How to use smart contract function with not imported contracts?
+        </span>
+      </AccordionTrigger>
+      <AccordionContent className="!pb-[0px]">
+        <ol className="flex flex-col gap-2 self-stretch list-decimal pl-4">
+          <li className="font-normal text-sm text-[#363b3f]">
+            Type =SMARTCONTRACT in cell.
+          </li>
+          <li>
+            <span className="font-normal text-sm text-[#363b3f]">
+              Follow next syntax
+            </span>
+            <div className="flex flex-col gap-2 self-stretch">
+              <div className="flex justify-center items-center gap-2 self-stretch bg-[hsl(var(--color-bg-default))] p-2 rounded border border-solid border-[#e8ebec] h-[48px] mt-2">
+                <code className="break-all">
+                  <span className="font-medium text-xs">
+                    =SMARTCONTRACT(
+                    <span className="text-[hsl(var(--color-text-success))]">
+                      &quot;Contract_address&quot;,&quot;Chain&quot;
+                    </span>
+                    )
+                  </span>
+                </code>
+                <CopyButton textToCopy='=SMARTCONTRACT("myContractName", "functionName", "arguments")' />
+              </div>
+              <div className="flex flex-col gap-1 self-stretch">
+                <span className="font-medium text-xs text-[#77818a]">
+                  Description
+                </span>
+                <div className="flex flex-col gap-1 self-stretch">
+                  <ParameterDescription
+                    paramName="contractAddress"
+                    description="Address of the contract you want to query"
+                  />
+                  <ParameterDescription
+                    paramName="Chain"
+                    description='Blockchain network(s) to query. Supported values: "ethereum", "gnosis", "base". Accepts comma-separated values.'
+                  />
+                </div>
+              </div>
+            </div>
+          </li>
+          <li className="font-normal text-sm text-[#363b3f]">
+            Get a response with list of available functions and arguments for
+            this contract address.
+          </li>
+          <li className="font-normal text-sm text-[#363b3f]">
+            Follow instructions of how to modify your =SMARTCONTRACT function
+            with function and argument from this list to query a data.
+          </li>
+          <li className="font-normal text-sm text-[#363b3f]">
+            Please spend some time to learn examples below
+            <CodeBlock
+              code={
+                <>
+                  =SMARTCONTRACT(
+                  <span className="text-[hsl(var(--color-text-success))]">
+                    &quot;0x75Df5AF045d91108662D8080fD1FEFAd6aA0bb59&quot;,
+                    &quot;GNOSIS&quot;
+                  </span>
+                  )
+                </>
+              }
+              copyText='=SMARTCONTRACT("0x75Df5AF045d91108662D8080fD1FEFAd6aA0bb59", "GNOSIS")'
+            />
+            <p className="text-[hsl(var(--color-text-default, #363B3F))] font-normal text-[12px] leading-5 font-[`Helvetica_Neue`] my-2">
+              Returning a list of all available functions for this particular
+              address.
+            </p>
+            <div className="flex justify-center items-center gap-2 self-stretch bg-[hsl(var(--color-bg-default))] p-2 rounded border border-solid border-[#e8ebec]">
+              <code className="break-all">
+                <span className="font-medium text-xs">
+                  =SMARTCONTRACT(
+                  <span className="text-[hsl(var(--color-text-success))]">
+                    &quot;0xdac17f958d2ee523a2206206994597c13d831ec7&quot;,
+                    &quot;ETHEREUM&quot;, &quot;balances&quot;,
+                    &quot;0x31b1ce9a747BEDBfe8F2d314ed05De6d045Bdb11&quot;
+                  </span>
+                  )
+                </span>
+              </code>
+              <CopyButton textToCopy='=SMARTCONTRACT("0xdac17f958d2ee523a2206206994597c13d831ec7", "ETHEREUM", "balances", "0x31b1ce9a747BEDBfe8F2d314ed05De6d045Bdb11")' />
+            </div>
+            <p className="text-[hsl(var(--color-text-default, #363B3F))] font-normal text-[12px] leading-5 font-[`Helvetica_Neue`] mt-2">
+              Returning a balance state for address that mentioned at the end of
+              function.
+            </p>
+          </li>
+        </ol>
+      </AccordionContent>
+    </AccordionItem>
+  </Accordion>
+);
+
+const ImportContractDocs: React.FC = () => (
+  <Accordion
+    type="single"
+    collapsible
+    defaultValue="item-a"
+    className="w-full accordin"
+  >
+    <AccordionItem value="item-a" className="border-none">
+      <AccordionTrigger className="!pl-[0px] hover:!bg-[#f8f9fa] !text-left">
+        <span className="font-medium text-sm text-[#363b3f]">
+          How to import contract?
+        </span>
+      </AccordionTrigger>
+      <AccordionContent className="!pb-[0px]">
+        <div className="flex flex-col gap-2 self-stretch pl-4">
+          <ol className="flex flex-col gap-2 self-stretch list-decimal">
+            <li className="font-normal text-sm text-[#363b3f]">
+              Click &quot;Import Contract&quot; above or select the action from
+              the toolbar on the right.
+            </li>
+            <li className="font-normal text-sm text-[#363b3f]">
+              Enter the contract address and choose the chain, then click
+              &quot;Import Smart Contract.&quot;
+            </li>
+            <li className="font-normal text-sm text-[#363b3f]">
+              Set a Contract Name. Youll use this later in function syntax as
+              &apos;contractName&apos;.
+            </li>
+            <ul className="flex flex-col gap-1 self-stretch pl-[10px]">
+              <li
+                className="font-normal text-sm text-[#363b3f]"
+                style={{ listStyleType: 'disc' }}
+              >
+                If the ABI cannot be fetched automatically, paste it or upload
+                an ABI .json file before setting the Contract Name.
+              </li>
+            </ul>
+            <li className="font-normal text-sm text-[#363b3f]">
+              Click &apos;Save smart contract&apos;
+            </li>
+          </ol>
+        </div>
+      </AccordionContent>
+    </AccordionItem>
+  </Accordion>
+);
+
+const UseImportedContractDocs: React.FC = () => (
+  <Accordion
+    type="single"
+    collapsible
+    defaultValue="item-a"
+    className="w-full accordin"
+  >
+    <AccordionItem value="item-a" className="border-none">
+      <AccordionTrigger className="!pl-[0px] hover:!bg-[#f8f9fa] !text-left">
+        <span className="font-medium text-sm text-[#363b3f]">
+          How to use imported contract?
+        </span>
+      </AccordionTrigger>
+      <AccordionContent className="!pb-[0px]">
+        <ol className="flex flex-col gap-2 self-stretch list-decimal pl-4">
+          <li>
+            <span className="font-normal text-sm text-[#363b3f]">
+              After importing a contract, you can pull data using the
+              =SMARTCONTRACT formula
+            </span>
+            <div className="flex flex-col gap-2 self-stretch">
+              <div className="flex justify-center items-center gap-2 self-stretch bg-[hsl(var(--color-bg-default))] p-2 rounded border border-solid border-[#e8ebec] h-[48px]">
+                <code>
+                  <span className="font-medium text-xs">
+                    =SMARTCONTRACT(
+                    <span className="text-[hsl(var(--color-text-success))]">
+                      &quot;myContractName&quot;, &quot;functionName&quot;,
+                      &quot;arguments&quot;
+                    </span>
+                    )
+                  </span>
+                </code>
+                <CopyButton textToCopy='=SMARTCONTRACT("myContractName", "functionName", "arguments")' />
+              </div>
+              <div className="flex flex-col gap-1 self-stretch">
+                <span className="font-medium text-xs text-[#77818a]">
+                  Description
+                </span>
+                <div className="flex flex-col gap-1 self-stretch">
+                  <ParameterDescription
+                    paramName="contract_name"
+                    description="Name of the contract, given by import, you want to pull data for"
+                  />
+                  <ParameterDescription
+                    paramName="functions"
+                    description="Name of the function you want to call from the given contract. See Functions section for more details."
+                  />
+                  <ParameterDescription
+                    paramName="argument"
+                    description="Optional arguments to pass to the contract function"
+                    optional
+                  />
+                </div>
+              </div>
+            </div>
+          </li>
+          <li className="font-normal text-sm text-[#363b3f]">
+            Enter formula and hit &apos;Enter&apos;. You should get in cell
+            output.{' '}
+          </li>
+          <li className="font-normal text-sm text-[#363b3f]">
+            Please spend some time to learn examples below
+            <CodeBlock
+              code={
+                <>
+                  =SMARTCONTRACT(
+                  <span className="text-[hsl(var(--color-text-success))]">
+                    &quot;myContractName&quot;, &quot;isBridge&quot;,
+                    &quot;_address&quot;
+                  </span>
+                  )
+                </>
+              }
+              copyText='=SMARTCONTRACT("myContractName", "isBridge", "_address")'
+            />
+            <CodeBlock
+              code={
+                <>
+                  =SMARTCONTRACT(
+                  <span className="text-[hsl(var(--color-text-success))]">
+                    &quot;myContractName&quot;, &quot;balanceOf&quot;,
+                    &quot;_owner&quot;
+                  </span>
+                  )
+                </>
+              }
+              copyText='=SMARTCONTRACT("myContractName", "balanceOf", "_owner")'
+            />
+            <CodeBlock
+              code={
+                <>
+                  =SMARTCONTRACT(
+                  <span className="text-[hsl(var(--color-text-success))]">
+                    &quot;myContractName&quot;, &quot;balanceOf&quot;,
+                    &quot;_owner&quot;
+                  </span>
+                  )
+                </>
+              }
+              copyText='=SMARTCONTRACT("myContractName", "balanceOf", "_owner")'
+            />
+          </li>
+        </ol>
+      </AccordionContent>
+    </AccordionItem>
+  </Accordion>
+);
+
+const DocSection: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <div className="flex flex-col gap-3 self-stretch bg-[#f8f9fa] px-3 py-2 rounded-lg">
+    {children}
+  </div>
+);
+
+// Main Components
+export const MyContracts: React.FC<MyContractsProps> = ({
+  contracts,
+  onDelete,
+  setActiveTab,
+  fetchContractAbi,
+}) => {
+  if (contracts.length === 0) {
+    return (
+      <div className="flex gap-2 mt-2 w-full">
+        <div>
+          <LucideIcon name="Info" className="color-text-secondary w-4 h-4" />
+        </div>
+        <p className="text-helper-text-sm color-text-secondary">
+          You have not added any smart contracts yet. You can easily add smart
+          contracts by clicking on the &quot;Add&quot; button above. See{' '}
+          <span
+            className="cursor-pointer text-[hsl(var(--color-text-link))]"
+            onClick={() => setActiveTab?.('documentation')}
+          >
+            Documentation
+          </span>
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="gap-2 flex flex-col">
+      {contracts.map((contract) => (
+        <SmartContractListItem
+          key={contract.name}
+          contract={contract}
+          onDelete={onDelete}
+          fetchContractAbi={fetchContractAbi}
+        />
+      ))}
+    </div>
+  );
+};
+
+export const PopularContracts: React.FC<PopularContractsProps> = ({
+  contracts,
+  fetchContractAbi,
+}) => {
+  if (contracts.length === 0) {
+    return (
+      <div className="flex gap-2 items-center mt-2 w-full">
+        <div className="flex">
+          <LucideIcon name="Info" className="color-text-secondary w-4 h-4" />
+        </div>
+        <p className="text-helper-text-sm color-text-secondary">
+          No popular contracts yet!
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="gap-2 flex flex-col">
+      {contracts.map((contract) => (
+        <SmartContractListItem
+          key={contract.name}
+          contract={contract}
+          fetchContractAbi={fetchContractAbi}
+        />
+      ))}
+    </div>
+  );
+};
+
+export const SmartContractListView: React.FC<SmartContractListViewProps> = ({
+  userSmartContracts,
+  onDelete,
+  handleSearch,
+  onOpenImportModal,
+  fetchContractAbi,
+  isAuthorized,
+}) => {
+  const [searchText, setSearchText] = useState('');
+  const [activeTab, setActiveTab] = useState('contracts');
+  const isUnAuthenticatedUser = !isAuthorized;
+
+  const [filteredContractList, setFilteredContractList] = useState<
+    ContractConfig[]
+  >(Object.values(POPULAR_CONTRACTS_MAP));
+
+  useEffect(() => {
+    handleSearch(searchText);
+
+    const filtered = Object.values(POPULAR_CONTRACTS_MAP).filter(
+      (contract) =>
+        contract.name.toLowerCase().includes(searchText.toLowerCase()) ||
+        contract.address.toLowerCase().includes(searchText.toLowerCase()) ||
+        contract.network.toLowerCase().includes(searchText.toLowerCase())
+    );
+
+    setFilteredContractList(filtered);
+  }, [searchText, handleSearch]);
+
+  const displayedContracts = searchText
+    ? filteredContractList
+    : Object.values(POPULAR_CONTRACTS_MAP);
+
+  return (
+    <div className="w-full h-[calc(100vh-200px)] flex flex-col gap-3 p-4">
+      <div className="flex gap-2 self-stretch">
+        <div className="flex flex-col justify-center h-[32px] grow">
+          <TextField
+            value={searchText}
+            className="!pl-10 h-full"
+            leftIcon={<LucideIcon name="Search" size="sm" />}
+            onChange={(e) => setSearchText(e.target.value)}
+            placeholder="Search by name, address, network"
+          />
+        </div>
+        <div className="h-[32px] w-[32px] flex justify-center items-center">
+          <IconButton
+            disabled={isUnAuthenticatedUser}
+            icon="Plus"
+            onClick={() => onOpenImportModal()}
+            className="!w-full h-full !min-w-[32px]"
+            size="md"
+            variant="default"
+          />
+        </div>
+      </div>
+
+      <div className="w-full overflow-y-auto no-scrollbar">
+        <Tabs
+          defaultValue="contracts"
+          className="w-full"
+          value={activeTab}
+          onValueChange={setActiveTab}
+        >
+          <TabsList className="w-full p-[0px] h-[32px]">
+            <TabsTrigger value="contracts" className="w-full">
+              Contracts
+            </TabsTrigger>
+            <TabsTrigger value="documentation" className="w-full">
+              Documentation
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="contracts" className="w-full mt-[16px]">
+            <div className="w-full">
+              <Accordion
+                type="multiple"
+                className="w-full accordin"
+                defaultValue={['item-1', 'item-2']}
+              >
+                <AccordionItem value="item-1" className="border-none">
+                  <AccordionTrigger
+                    size="md"
+                    className="!pl-[0px] hover:!bg-[hsl(var(--color-bg-default))]"
+                  >
+                    Imported Contracts
+                  </AccordionTrigger>
+                  <AccordionContent className="!pb-[24px]">
+                    <MyContracts
+                      contracts={userSmartContracts}
+                      onDelete={onDelete}
+                      setActiveTab={setActiveTab}
+                      fetchContractAbi={fetchContractAbi}
+                    />
+                  </AccordionContent>
+                </AccordionItem>
+
+                <AccordionItem value="item-2" className="border-none">
+                  <AccordionTrigger
+                    size="md"
+                    className="!pl-[0px] hover:!bg-[hsl(var(--color-bg-default))]"
+                  >
+                    Popular Contracts
+                  </AccordionTrigger>
+                  <AccordionContent>
+                    <PopularContracts
+                      contracts={displayedContracts}
+                      onInsert={(name) => console.log(name)}
+                      fetchContractAbi={fetchContractAbi}
+                    />
+                  </AccordionContent>
+                </AccordionItem>
+              </Accordion>
+            </div>
+          </TabsContent>
+
+          <TabsContent value="documentation" className="w-full">
+            <div className="flex flex-col gap-5 self-stretch">
+              <div className="flex flex-col gap-2 self-stretch mt-[12px]">
+                <DocSection>
+                  <NonImportedContractDocs />
+                </DocSection>
+                <DocSection>
+                  <ImportContractDocs />
+                </DocSection>
+                <DocSection>
+                  <UseImportedContractDocs />
+                </DocSection>
+              </div>
+            </div>
+          </TabsContent>
+        </Tabs>
+      </div>
+    </div>
+  );
+};

--- a/src/editor/components/smart-contract/use-address-validation.ts
+++ b/src/editor/components/smart-contract/use-address-validation.ts
@@ -1,0 +1,22 @@
+import { useState, useCallback } from 'react';
+import { isAddress } from 'viem';
+
+export const useAddressValidation = () => {
+  const [isValidAddress, setIsValidAddress] = useState(false);
+
+  const handleAddressChange = (address: string) => {
+    const valid = isAddress(address);
+    setIsValidAddress(valid);
+    return valid;
+  };
+
+  const resetValidation = useCallback(() => {
+    setIsValidAddress(false);
+  }, []);
+
+  return {
+    isValidAddress,
+    handleAddressChange,
+    resetValidation,
+  };
+};

--- a/src/editor/components/smart-contract/use-modal-outside-click.ts
+++ b/src/editor/components/smart-contract/use-modal-outside-click.ts
@@ -1,0 +1,56 @@
+import { useState, useCallback, useRef, MutableRefObject } from 'react';
+import { useOnClickOutside } from 'usehooks-ts';
+
+interface UseFetchUrlModalProps {
+  onClose?: () => void;
+  setInputAddress?: React.Dispatch<React.SetStateAction<string>>;
+  shouldPreventClose?: MutableRefObject<boolean>;
+}
+
+export const useModalOutsideClick = ({
+  onClose,
+  setInputAddress,
+  shouldPreventClose,
+}: UseFetchUrlModalProps = {}) => {
+  const [rowCount, setRowCount] = useState<number>(100);
+  const [includeHeaders, setIncludeHeaders] = useState<boolean>(true);
+  const [abortCall, setAbortCall] = useState<boolean>(false);
+
+  const modalDivRef = useRef<HTMLDivElement>(null);
+
+  const resetModalState = useCallback(() => {
+    setInputAddress?.('');
+    setRowCount(100);
+    setIncludeHeaders(true);
+    setAbortCall(false);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    resetModalState();
+    onClose?.();
+  }, [resetModalState, onClose]);
+
+  useOnClickOutside(modalDivRef, (e) => {
+    const target = e.target as HTMLElement;
+
+    // Skip if clicked inside radix select content
+    if (
+      target.closest('[data-radix-popper-content-wrapper]') ||
+      shouldPreventClose?.current
+    ) {
+      return;
+    }
+    handleClose();
+  });
+
+  return {
+    rowCount,
+    setRowCount,
+    includeHeaders,
+    setIncludeHeaders,
+    abortCall,
+    modalDivRef,
+    resetModalState,
+    handleClose,
+  };
+};

--- a/src/editor/components/smart-contract/use-smart-contract-modal.ts
+++ b/src/editor/components/smart-contract/use-smart-contract-modal.ts
@@ -1,0 +1,214 @@
+import { useState, useRef, useEffect } from 'react';
+import { Abi, Hex } from 'viem';
+import type { ContractConfig } from '../../types/smart-contract';
+import { SupportedChain } from '../../types/smart-contract';
+import { useAddressValidation } from './use-address-validation';
+import { useModalOutsideClick } from './use-modal-outside-click';
+import {
+  validateAbi,
+  parseAbiViewFunctions,
+} from '../../utils/smart-contract/reading-utils';
+
+export function useSmartContractModal({
+  onSaveContract,
+  setShowSmartContractModal,
+  registryMapRef,
+}: {
+  onSaveContract: (
+    address: Hex,
+    chain: SupportedChain,
+    abi: string,
+    smartContractName: string
+  ) => Promise<void>;
+  setShowSmartContractModal: (show: boolean) => void;
+  registryMapRef: React.MutableRefObject<Record<string, ContractConfig>>;
+}) {
+  const [inputAddress, setInputAddress] = useState<string>('');
+  const [selectedChain, setSelectedChain] = useState<SupportedChain>(
+    SupportedChain.Ethereum
+  );
+  const [formStep, setFormStep] = useState<number>(1);
+  const [abiCode, setAbiCode] = useState('');
+  const [uploadedFile, setUploadedFile] = useState<any>(null);
+  const [uploadProgress, setUploadProgress] = useState(0);
+  const [isUploading, setIsUploading] = useState(false);
+  const fileInputRef = useRef<any>(null);
+  const [smartContractName, setSmartContractName] = useState('');
+  const isImportingRef = useRef(false);
+
+  const formatFileSize = (bytes: any) => {
+    if (bytes === 0) return '0 Bytes';
+    const k = 1024;
+    const sizes = ['Bytes', 'KB', 'MB', 'GB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + ' ' + sizes[i];
+  };
+
+  const validateJsonFile = (file: any) => {
+    return file.type === 'application/json' || file.name.endsWith('.json');
+  };
+
+  const readFileContent = (file: any) => {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        try {
+          // @ts-expect-error later
+          const content = e.target.result;
+          JSON.parse(content as string);
+          resolve(content);
+        } catch (error) {
+          reject(new Error('Invalid JSON file'));
+        }
+      };
+      reader.onerror = () => reject(new Error('Failed to read file'));
+      reader.readAsText(file);
+    });
+  };
+
+  const handleFileUpload = async (file: any) => {
+    if (!validateJsonFile(file)) {
+      setError({ message: 'Invalid JSON file' });
+      return;
+    }
+    setUploadProgress(0);
+    try {
+      setUploadedFile({
+        name: file?.name,
+        size: formatFileSize(file.size),
+      });
+      setUploadProgress(50);
+      // handle file upload to ipfs
+      const content = await readFileContent(file);
+      validateAbi(content);
+      setUploadProgress(100);
+      setAbiCode(content as string);
+      setIsUploading(false);
+    } catch (error: any) {
+      setError({ message: error.message });
+      handleRemoveFile();
+    }
+  };
+
+  const handleFileInputChange = (e: any) => {
+    const file = e.target.files[0];
+    if (file) {
+      handleFileUpload(file);
+    }
+  };
+
+  const handleUploadAreaClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleRemoveFile = () => {
+    setUploadedFile(null);
+    setUploadProgress(0);
+    setIsUploading(false);
+    setAbiCode('');
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  };
+
+  const onClose = () => {
+    setUploadProgress(0);
+    resetValidation();
+    setSmartContractName('');
+    setFormStep(1);
+    setAbiCode('');
+    setInputAddress('');
+    setUploadedFile(null);
+    setShowSmartContractModal(false);
+    isImportingRef.current = false;
+  };
+
+  const { modalDivRef } = useModalOutsideClick({
+    onClose: () => {
+      onClose();
+    },
+    setInputAddress,
+    shouldPreventClose: isImportingRef,
+  });
+
+  const { isValidAddress, handleAddressChange, resetValidation } =
+    useAddressValidation();
+
+  const handleAddressInputChange = (url: string) => {
+    setInputAddress(url);
+    handleAddressChange(url);
+  };
+
+  const onClickProceed = async (abi?: any) => {
+    const _abi = abi || abiCode;
+    if (!_abi || !smartContractName) return;
+    isImportingRef.current = true;
+    await onSaveContract(
+      inputAddress as Hex,
+      selectedChain,
+      _abi,
+      smartContractName
+    );
+    onClose();
+  };
+
+  const isVaildJsonType = (abi: string) => {
+    try {
+      return !!JSON.parse(abi);
+    } catch (error) {
+      return false;
+    }
+  };
+
+  const [errorState, setError] = useState<{ message: string } | null>(null);
+
+  useEffect(() => {
+    if (abiCode) {
+      if (isVaildJsonType(abiCode)) {
+        const parse = parseAbiViewFunctions(JSON.parse(abiCode) as Abi);
+        if (!parse.length) {
+          setError({
+            message:
+              'Please make sure you are uploading a Json file that contains at least one view function as part of the ABI',
+          });
+        } else {
+          setError(null);
+        }
+      } else {
+        setError({
+          message: 'Invalid ABI',
+        });
+      }
+    }
+  }, [abiCode]);
+
+  return {
+    inputAddress,
+    setInputAddress,
+    selectedChain,
+    setSelectedChain,
+    formStep,
+    setFormStep,
+    abiCode,
+    setAbiCode,
+    uploadedFile,
+    setUploadedFile,
+    uploadProgress,
+    setUploadProgress,
+    isUploading,
+    setIsUploading,
+    fileInputRef,
+    smartContractName,
+    setSmartContractName,
+    isImportingRef,
+    modalDivRef,
+    handleFileInputChange,
+    handleUploadAreaClick,
+    handleRemoveFile,
+    handleAddressInputChange,
+    onClickProceed,
+    isValidAddress,
+    registryMapRef,
+    errorState,
+  };
+}

--- a/src/editor/contexts/editor-context.tsx
+++ b/src/editor/contexts/editor-context.tsx
@@ -27,6 +27,8 @@ import {
   defaultApiKeyStorage,
 } from '../utils/api-key-storage';
 import type { OpenApiKeyModalFn } from '../utils/data-block-error-handler';
+import type { SmartContractConfig } from '../types/smart-contract';
+import { useSmartContract, type UseSmartContractReturn } from '../hooks/use-smart-contract';
 import { SidebarProvider } from '../components/sidebar/sidebar-context';
 import { SidebarPortalRegistryProvider } from '../components/sidebar/sidebar-portal-registry';
 import type {
@@ -92,6 +94,7 @@ export interface EditorContextType {
     onSave: (key: string) => void;
     onClose: () => void;
   } | null;
+  smartContract: UseSmartContractReturn;
 }
 
 // Create the context with a default value
@@ -100,7 +103,6 @@ const EditorContext = createContext<EditorContextType | undefined>(undefined);
 // Props for the provider component
 interface EditorProviderProps {
   setSelectedTemplate?: React.Dispatch<React.SetStateAction<string>>;
-  setShowSmartContractModal?: React.Dispatch<React.SetStateAction<boolean>>;
   getDocumentTitle?: (dsheetId: string) => Promise<string>;
   updateDocumentTitle?: (title: string) => void;
   isAuthorized: boolean;
@@ -124,12 +126,12 @@ interface EditorProviderProps {
   liveQueryRefreshRate?: number;
   apiKeyStorage?: ApiKeyStorage;
   onDataBlockEvent?: (event: DataBlockEvent) => void;
+  smartContracts?: SmartContractConfig;
 }
 
 // Provider component that wraps the app
 export const EditorProvider: React.FC<EditorProviderProps> = ({
   setSelectedTemplate,
-  setShowSmartContractModal,
   getDocumentTitle,
   updateDocumentTitle,
   children,
@@ -148,6 +150,7 @@ export const EditorProvider: React.FC<EditorProviderProps> = ({
   liveQueryRefreshRate,
   apiKeyStorage: apiKeyStorageProp,
   onDataBlockEvent,
+  smartContracts,
 }) => {
   // Comments are driven entirely by commentsConfig (the legacy
   // commentData/allowComments props were removed).
@@ -165,6 +168,8 @@ export const EditorProvider: React.FC<EditorProviderProps> = ({
     () => apiKeyStorageProp ?? defaultApiKeyStorage,
     [apiKeyStorageProp],
   );
+
+  const smartContract = useSmartContract(smartContracts);
 
   const [apiKeyModalState, setApiKeyModalState] = useState<{
     open: boolean;
@@ -466,7 +471,7 @@ export const EditorProvider: React.FC<EditorProviderProps> = ({
   const contextValue: EditorContextType = useMemo(() => {
     return {
       setSelectedTemplate,
-      setShowSmartContractModal,
+      setShowSmartContractModal: smartContract.setShowSmartContractModal,
       getDocumentTitle,
       updateDocumentTitle,
       dataBlockCalcFunction,
@@ -507,10 +512,11 @@ export const EditorProvider: React.FC<EditorProviderProps> = ({
       onDataBlockEvent,
       openApiKeyModal,
       apiKeyModalState,
+      smartContract,
     };
   }, [
     setIsDataLoaded,
-    setShowSmartContractModal,
+    smartContract,
     getDocumentTitle,
     updateDocumentTitle,
     dataBlockCalcFunction,

--- a/src/editor/dsheet-editor.tsx
+++ b/src/editor/dsheet-editor.tsx
@@ -17,8 +17,6 @@ import { TransitionWrapper } from './components/transition-wrapper';
 import { PermissionChip } from './components/permission-chip';
 import '@sheet-engine/react/index.css';
 import './styles/index.css';
-import { SmartContractQueryHandler } from './utils/after-update-cell';
-import { Workbook } from '@sheet-engine/react';
 import { useSidebar } from './components/sidebar/sidebar-context';
 import { useSidebarPortalRegistryHandle } from './components/sidebar/sidebar-portal-registry';
 import { EditorRightSidebar } from './components/sidebar/editor-right-sidebar';
@@ -32,6 +30,12 @@ import { useMediaQuery } from 'usehooks-ts';
 import { CommentsContent } from './components/comments/comment-sidebar';
 import { setEnsResolutionUrl } from './components/comments/ens/ens-cache';
 import { CommentsConfig } from './types/comments';
+import { SmartContractModal } from './components/smart-contract/smart-contract-modal';
+import { SmartContractListView } from './components/smart-contract/smart-contract-view-list';
+import { SmartContractReadingIntro } from './components/smart-contract/smart-contract-reading-intro';
+import { SmartContractReadingErrorToast } from './components/smart-contract/error-toast';
+import { SMART_CONTRACT_PANEL_ID } from './utils/smart-contract/constants';
+import './components/smart-contract/index.css';
 
 // Use the types defined in types.ts
 type OnboardingHandler = OnboardingHandlerType;
@@ -59,7 +63,6 @@ const EditorContent = ({
   setInputFetchURLDataBlock,
   onDuneChartEmbed,
   onSheetCountChange,
-  handleSmartContractQuery,
   isNewSheet,
   customPanels,
   theme,
@@ -86,7 +89,6 @@ const EditorContent = ({
   onboardingHandler?: OnboardingHandler;
   onDuneChartEmbed?: () => void;
   onSheetCountChange?: (sheetCount: number) => void;
-  handleSmartContractQuery?: SmartContractQueryHandler;
   customPanels?: PanelConfig[];
 }) => {
   const {
@@ -101,6 +103,8 @@ const EditorContent = ({
     initialiseLiveQueryData,
     setSelectedTemplate: contextSetSelectedTemplate,
     apiKeyModalState,
+    isAuthorized,
+    smartContract,
   } = useEditor();
 
   const { activePanel, isOpen, openPanel, closePanel, togglePanel } =
@@ -123,6 +127,27 @@ const EditorContent = ({
   const isMobile = useMediaQuery('(max-width: 840px)', { defaultValue: false });
 
   const builtInPanels: PanelConfig[] = [
+    ...(smartContract.enabled
+      ? [
+          {
+            id: SMART_CONTRACT_PANEL_ID,
+            header: { title: 'My smart contracts' },
+            width: '380px',
+            content: (
+              <SmartContractListView
+                userSmartContracts={smartContract.userSmartContracts}
+                onDelete={smartContract.onDelete}
+                handleSearch={smartContract.handleSearch}
+                onOpenImportModal={() =>
+                  smartContract.setShowSmartContractModal(true)
+                }
+                fetchContractAbi={smartContract.fetchContractAbi}
+                isAuthorized={isAuthorized}
+              />
+            ),
+          },
+        ]
+      : []),
     ...(commentsConfig
       ? [
         {
@@ -341,7 +366,12 @@ const EditorContent = ({
       <button
         id="smartcontract-button"
         className="hidden"
-        onClick={() => openPanel('smart-contract-list-view')}
+        onClick={() => openPanel(SMART_CONTRACT_PANEL_ID)}
+      />
+      <button
+        id="view-smart-contract"
+        className="hidden"
+        onClick={() => openPanel(SMART_CONTRACT_PANEL_ID)}
       />
       <button
         id="function-button"
@@ -405,7 +435,6 @@ const EditorContent = ({
             dsheetId={dsheetId}
             onDuneChartEmbed={onDuneChartEmbed}
             onSheetCountChange={onSheetCountChange}
-            handleSmartContractQuery={handleSmartContractQuery}
             sidebarActivePanel={activePanel}
             sidebarPortalRegistry={sidebarPortalRegistry}
             theme={theme}
@@ -430,6 +459,28 @@ const EditorContent = ({
           onSave={apiKeyModalState.onSave}
           onClose={apiKeyModalState.onClose}
         />
+      )}
+
+      {smartContract.enabled && (
+        <>
+          <SmartContractModal
+            showSmartContractModal={smartContract.showSmartContractModal}
+            setShowSmartContractModal={smartContract.setShowSmartContractModal}
+            onSaveContract={smartContract.onImportContract}
+            registryMapRef={smartContract.registryMapRef}
+          />
+          <SmartContractReadingIntro
+            isAuthorized={isAuthorized}
+            onOpenPanel={openPanel}
+          />
+          <SmartContractReadingErrorToast
+            smartContractReadingError={smartContract.smartContractReadingError}
+            setSmartContractReadingError={
+              smartContract.setSmartContractReadingError
+            }
+            openPanel={openPanel}
+          />
+        </>
       )}
     </div>
   );
@@ -467,9 +518,7 @@ const SpreadsheetEditor = ({
   isAuthorized,
   getDocumentTitle,
   updateDocumentTitle,
-  setShowSmartContractModal,
   editorStateRef,
-  handleSmartContractQuery,
   setSelectedTemplate,
   isNewSheet,
   liveQueryRefreshRate,
@@ -478,6 +527,7 @@ const SpreadsheetEditor = ({
   customPanels,
   apiKeyStorage,
   onDataBlockEvent,
+  smartContracts,
   theme,
 }: DsheetProps): JSX.Element => {
   const [exportDropdownOpen, setExportDropdownOpen] = useState<boolean>(false);
@@ -485,7 +535,6 @@ const SpreadsheetEditor = ({
   return (
     <EditorProvider
       setSelectedTemplate={setSelectedTemplate}
-      setShowSmartContractModal={setShowSmartContractModal}
       getDocumentTitle={getDocumentTitle}
       updateDocumentTitle={updateDocumentTitle}
       dsheetId={dsheetId}
@@ -503,6 +552,7 @@ const SpreadsheetEditor = ({
       enableLiveQuery={enableLiveQuery}
       apiKeyStorage={apiKeyStorage}
       onDataBlockEvent={onDataBlockEvent}
+      smartContracts={smartContracts}
     >
       <EditorContent
         commentsConfig={commentsConfig}
@@ -524,7 +574,6 @@ const SpreadsheetEditor = ({
         selectedTemplate={selectedTemplate}
         onDuneChartEmbed={onDuneChartEmbed}
         onSheetCountChange={onSheetCountChange}
-        handleSmartContractQuery={handleSmartContractQuery}
         customPanels={customPanels}
         theme={theme}
       />

--- a/src/editor/hooks/use-smart-contract.ts
+++ b/src/editor/hooks/use-smart-contract.ts
@@ -1,0 +1,283 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { isAddress, type Abi, type Hex } from 'viem';
+import type { Cell, WorkbookInstance } from '@sheet-engine/react';
+import type {
+  ContractConfig,
+  ContractRegistry,
+  NewContractInput,
+  SmartContractConfig,
+  SupportedChain,
+} from '../types/smart-contract';
+import type { SmartContractQueryHandler } from '../utils/after-update-cell';
+import { formulaResponseUiSync } from '../utils/formula-ui-sync';
+import {
+  POPULAR_CONTRACTS_MAP,
+  POPULAR_CONTRACT_NAMES,
+} from '../utils/smart-contract/constants';
+import {
+  executeSmartContractCall,
+  fetchContractAbi,
+  normalizeGridArray,
+  parseCallSignature,
+  type SmartContractRuntimeDeps,
+} from '../utils/smart-contract/reading-utils';
+
+const buildRegistry = (
+  persisted: ContractConfig[],
+  memory: ContractConfig[],
+): ContractRegistry => {
+  const userMap = Object.fromEntries(
+    [...persisted, ...memory].map((c) => [c.name, c]),
+  );
+  return { ...POPULAR_CONTRACTS_MAP, ...userMap };
+};
+
+export const useSmartContract = (config?: SmartContractConfig) => {
+  const [showSmartContractModal, setShowSmartContractModal] = useState(false);
+  const [memoryContracts, setMemoryContracts] = useState<ContractConfig[]>([]);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [smartContractReadingError, setSmartContractReadingError] = useState({
+    hasError: false,
+    errorMessage: '',
+  });
+
+  const abiCacheRef = useRef<Record<string, Abi>>({});
+  const registryMapRef = useRef<ContractRegistry>({});
+
+  const persistedContracts = config?.contracts ?? [];
+
+  const userContracts = useMemo(
+    () => [...persistedContracts, ...memoryContracts],
+    [persistedContracts, memoryContracts],
+  );
+
+  const registry = useMemo(
+    () => buildRegistry(persistedContracts, memoryContracts),
+    [persistedContracts, memoryContracts],
+  );
+
+  useEffect(() => {
+    registryMapRef.current = registry;
+  }, [registry]);
+
+  const runtimeDeps = useMemo<SmartContractRuntimeDeps>(
+    () => ({
+      resolveAbi: config?.resolveAbi,
+      rpcConfig: config?.rpcConfig,
+      abiCache: abiCacheRef.current,
+    }),
+    [config?.resolveAbi, config?.rpcConfig],
+  );
+
+  const fetchContractAbiFn = useCallback(
+    (contract: ContractConfig) => fetchContractAbi(contract, runtimeDeps),
+    [runtimeDeps],
+  );
+
+  const displayedUserContracts = useMemo(() => {
+    if (!searchQuery) return userContracts;
+    const q = searchQuery.toLowerCase();
+    return userContracts.filter(
+      (c) =>
+        c.name.toLowerCase().includes(q) ||
+        c.address.toLowerCase().includes(q) ||
+        c.network.toLowerCase().includes(q),
+    );
+  }, [userContracts, searchQuery]);
+
+  const handleSearch = useCallback((searchText: string) => {
+    setSearchQuery(searchText);
+  }, []);
+
+  const onImportContract = useCallback(
+    async (
+      address: Hex,
+      network: SupportedChain,
+      abiJson: string,
+      smartContractName: string,
+    ) => {
+      const abi = JSON.parse(abiJson) as Abi;
+      const input: NewContractInput = {
+        address,
+        network,
+        name: smartContractName,
+        abi,
+      };
+
+      if (config?.onAddContract) {
+        await config.onAddContract(input);
+      } else {
+        const memoryEntry: ContractConfig = {
+          name: smartContractName,
+          address,
+          network,
+          abiHash: `memory:${smartContractName}`,
+        };
+        abiCacheRef.current[memoryEntry.abiHash] = abi;
+        setMemoryContracts((prev) => [
+          ...prev.filter((c) => c.name !== smartContractName),
+          memoryEntry,
+        ]);
+      }
+
+      config?.onSmartContractEvent?.({
+        type: 'contract-added',
+        contractName: smartContractName,
+      });
+    },
+    [config],
+  );
+
+  const onDelete = useCallback(
+    async (name: string) => {
+      if (POPULAR_CONTRACT_NAMES.has(name)) return;
+
+      const isMemory = memoryContracts.some((c) => c.name === name);
+      const isPersisted = persistedContracts.some((c) => c.name === name);
+
+      if (isPersisted && config?.onDeleteContract) {
+        await config.onDeleteContract(name);
+      } else if (isMemory) {
+        setMemoryContracts((prev) => prev.filter((c) => c.name !== name));
+      }
+
+      config?.onSmartContractEvent?.({
+        type: 'contract-deleted',
+        contractName: name,
+      });
+    },
+    [config, memoryContracts, persistedContracts],
+  );
+
+  const handleSmartContractQuery: SmartContractQueryHandler = useCallback(
+    (sheetApi) => async (callSignature) => {
+      if (!config) {
+        throw new Error('Smart contract support is not configured');
+      }
+
+      setSmartContractReadingError({ hasError: false, errorMessage: '' });
+
+      const [contractName, functionName, ...args] = callSignature as [
+        string,
+        string,
+        ...unknown[],
+      ];
+      if (isAddress(contractName)) {
+        args.shift();
+      }
+
+      const { row, column, newValue, sheetEditorRef, formulaResponseUiSync: sync } =
+        sheetApi;
+
+      try {
+        sheetEditorRef.current?.setCellValue(row, column, {
+          ...newValue,
+          m: 'Loading Smart contract ...',
+        });
+
+        const callerParams = await parseCallSignature(
+          callSignature,
+          registryMapRef.current,
+          runtimeDeps,
+        );
+
+        const normalisedArgs = normalizeGridArray(
+          args,
+          functionName,
+          callerParams.abi,
+        );
+        callerParams.args = normalisedArgs;
+
+        const { response, staticInstructions } = await executeSmartContractCall(
+          callerParams,
+          runtimeDeps,
+        );
+
+        if (Array.isArray(response)) {
+          await sync({
+            row,
+            column,
+            newValue: newValue as Record<string, string>,
+            apiData: response,
+            sheetEditorRef,
+            staticLinesAbove: staticInstructions,
+          });
+          sheetEditorRef.current?.clearCellError(row, column);
+        } else if (['string', 'number', 'boolean'].includes(typeof response)) {
+          const key =
+            typeof callerParams.functionName === 'string'
+              ? callerParams.functionName
+              : '0';
+          await sync({
+            row,
+            column,
+            newValue: newValue as Record<string, string>,
+            apiData: [{ [key]: response }],
+            sheetEditorRef,
+          });
+          sheetEditorRef.current?.clearCellError(row, column);
+        } else {
+          sheetEditorRef.current?.setCellValue(row, column, {
+            ...newValue,
+            m: 'Unsupported return type',
+            isDataBlockFormula: true,
+          });
+        }
+
+        config.onSmartContractEvent?.({
+          type: 'query-success',
+          contractName,
+          functionName,
+        });
+      } catch (error: unknown) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : 'Failed to execute smart contract';
+
+        setSmartContractReadingError({
+          hasError: true,
+          errorMessage: message,
+        });
+
+        sheetEditorRef.current?.setCellValue(row, column, {
+          ...newValue,
+          m: '#ERROR',
+          isDataBlockFormula: true,
+        });
+        sheetEditorRef.current?.setCellError(row, column, {
+          title: 'Smart Contract Error',
+          message,
+        });
+
+        config.onSmartContractEvent?.({
+          type: 'query-error',
+          contractName,
+          functionName,
+          errorMessage: message,
+        });
+      }
+    },
+    [config, runtimeDeps],
+  );
+
+  const enabled = Boolean(config);
+
+  return {
+    enabled,
+    showSmartContractModal,
+    setShowSmartContractModal,
+    userSmartContracts: displayedUserContracts,
+    allUserContracts: userContracts,
+    registryMapRef,
+    handleSmartContractQuery: enabled ? handleSmartContractQuery : undefined,
+    onImportContract,
+    onDelete,
+    handleSearch,
+    smartContractReadingError,
+    setSmartContractReadingError,
+    fetchContractAbi: fetchContractAbiFn,
+  };
+};
+
+export type UseSmartContractReturn = ReturnType<typeof useSmartContract>;

--- a/src/editor/types.ts
+++ b/src/editor/types.ts
@@ -4,9 +4,9 @@ import { WorkbookInstance } from '@sheet-engine/react';
 import * as Y from 'yjs';
 import { Cell } from '@sheet-engine/react';
 import { ERROR_MESSAGES_FLAG } from './constants/shared-constants';
-import { SmartContractQueryHandler } from './utils/after-update-cell';
 import { CollaborationProps } from '../sync-local/types';
 import { CommentsConfig } from './types/comments';
+import type { SmartContractConfig } from './types/smart-contract';
 import type { ApiKeyStorage } from './utils/api-key-storage';
 import type { ThemeKey } from '@sheet-engine/core/theme';
 
@@ -73,7 +73,6 @@ export type { ApiKeyStorage } from './utils/api-key-storage';
 export interface DsheetProps {
   isNewSheet: boolean;
   setSelectedTemplate?: React.Dispatch<React.SetStateAction<string>>;
-  setShowSmartContractModal?: React.Dispatch<React.SetStateAction<boolean>>;
   getDocumentTitle?: (dsheetId: string) => Promise<string>;
   updateDocumentTitle?: (title: string) => void;
   isAuthorized: boolean;
@@ -110,7 +109,8 @@ export interface DsheetProps {
   editorStateRef?: React.MutableRefObject<{
     refreshIndexedDB: () => Promise<void>;
   } | null>;
-  handleSmartContractQuery?: SmartContractQueryHandler;
+  /** Smart contract config: execution + UI in package; consumer owns persistence via callbacks. */
+  smartContracts?: SmartContractConfig;
   enableLiveQuery?: boolean;
   liveQueryRefreshRate?: number;
   customPanels?: PanelConfig[];

--- a/src/editor/types/smart-contract.ts
+++ b/src/editor/types/smart-contract.ts
@@ -1,0 +1,109 @@
+import type { Abi, Hex } from 'viem';
+import type React from 'react';
+
+export enum SupportedChain {
+  Ethereum = 'Ethereum',
+  Sepolia = 'Sepolia',
+  Gnosis = 'Gnosis',
+  Base = 'Base',
+}
+
+export interface ContractConfig {
+  address: Hex;
+  abiHash: string;
+  network: SupportedChain;
+  name: string;
+}
+
+export type ContractRegistry = Record<string, ContractConfig>;
+
+export interface NewContractInput {
+  name: string;
+  address: Hex;
+  network: SupportedChain;
+  abi: Abi;
+}
+
+export type SmartContractEventType =
+  | 'query-success'
+  | 'query-error'
+  | 'contract-added'
+  | 'contract-deleted';
+
+export interface SmartContractEvent {
+  type: SmartContractEventType;
+  contractName?: string;
+  functionName?: string;
+  chainName?: string;
+  errorMessage?: string;
+}
+
+export interface SmartContractConfig {
+  /** User's persisted private contracts from consumer keystore. Defaults to []. */
+  contracts?: ContractConfig[];
+  /** RPC URL per chain. Falls back to bundled defaults when omitted. */
+  rpcConfig?: Partial<Record<SupportedChain, string>>;
+  /** Resolve ABI from stored reference (e.g. IPFS hash). Required for user-saved contracts with abiHash. */
+  resolveAbi?: (abiHash: string) => Promise<Abi>;
+  /** Persist a new contract. When omitted, package keeps it in session memory only. */
+  onAddContract?: (input: NewContractInput) => Promise<void>;
+  /** Remove a persisted contract. When omitted, package removes from session memory only. */
+  onDeleteContract?: (contractName: string) => Promise<void>;
+  validateAddress?: (
+    address: string,
+    chain: SupportedChain,
+  ) => boolean | Promise<boolean>;
+  onSmartContractEvent?: (event: SmartContractEvent) => void;
+}
+
+export interface CallerParams {
+  abi: Abi;
+  contractAddress: Hex;
+  chain: import('viem').Chain;
+  functionName?: string;
+  args?: unknown[];
+}
+
+export interface FetchAbiParams {
+  contractAddress: Hex;
+  chain: import('viem').Chain;
+  ipfsHash?: string;
+}
+
+export type ParsedFunction = {
+  functionName: string;
+  output: string;
+};
+
+export interface SmartContractListViewProps {
+  userSmartContracts: ContractConfig[];
+  onDelete: (name: string) => void;
+  handleSearch: (searchText: string) => void;
+  onOpenImportModal: () => void;
+  fetchContractAbi: (contract: ContractConfig) => Promise<Abi>;
+  isAuthorized: boolean;
+}
+
+export interface MyContractsProps {
+  contracts: ContractConfig[];
+  onDelete: (name: string) => void;
+  fetchContractAbi: (contract: ContractConfig) => Promise<Abi>;
+  setActiveTab?: React.Dispatch<React.SetStateAction<string>>;
+}
+
+export interface PopularContractsProps {
+  contracts: ContractConfig[];
+  onInsert: (name: string) => void;
+  fetchContractAbi: (contract: ContractConfig) => Promise<Abi>;
+}
+
+export interface CodeBlockProps {
+  code: React.ReactNode;
+  copyText: string;
+}
+
+export interface ParameterDescriptionProps {
+  paramName: string;
+  description: string;
+  optional?: boolean;
+}

--- a/src/editor/utils/custom-toolbar-item.tsx
+++ b/src/editor/utils/custom-toolbar-item.tsx
@@ -80,22 +80,26 @@ export const getCustomToolbarItems = ({
   | undefined;
 }) => {
   return [
-    {
-      key: 'Smart Contract',
-      tooltip: 'Smart Contract',
-      icon: (
-        <SmartContractButton
-          handleImportSmartContract={() =>
-            setShowSmartContractModal?.((prev: boolean) => {
-              return !prev;
-            })
-          }
-          handleViewSmartContract={() =>
-            document.getElementById('view-smart-contract')?.click()
-          }
-        />
-      ),
-    },
+    ...(setShowSmartContractModal
+      ? [
+          {
+            key: 'Smart Contract',
+            tooltip: 'Smart Contract',
+            icon: (
+              <SmartContractButton
+                handleImportSmartContract={() =>
+                  setShowSmartContractModal?.((prev: boolean) => {
+                    return !prev;
+                  })
+                }
+                handleViewSmartContract={() =>
+                  document.getElementById('view-smart-contract')?.click()
+                }
+              />
+            ),
+          },
+        ]
+      : []),
     {
       key: 'import-export',
       tooltip: 'Import/Export',

--- a/src/editor/utils/smart-contract/constants.ts
+++ b/src/editor/utils/smart-contract/constants.ts
@@ -1,0 +1,83 @@
+import { base, gnosis, mainnet, sepolia } from 'viem/chains';
+import type { ContractConfig } from '../../types/smart-contract';
+import { SupportedChain } from '../../types/smart-contract';
+
+export const DEFAULT_RPC_URL_MAP: Record<SupportedChain, string[]> = {
+  [SupportedChain.Sepolia]: [
+    'https://eth-sepolia.g.alchemy.com/v2/iu7jObrJF2MAYHNrVwuh7cah4xg9g8iN',
+  ],
+  [SupportedChain.Gnosis]: [
+    'https://gnosis-mainnet.g.alchemy.com/v2/yB7FBP7D-qhIPCGwiU1X-',
+  ],
+  [SupportedChain.Base]: [
+    'https://base-mainnet.g.alchemy.com/v2/yB7FBP7D-qhIPCGwiU1X-',
+  ],
+  [SupportedChain.Ethereum]: [
+    'https://eth-mainnet.g.alchemy.com/v2/yB7FBP7D-qhIPCGwiU1X-',
+  ],
+};
+
+export const SUPPORTED_VIEM_CHAIN_MAP = {
+  [SupportedChain.Sepolia]: sepolia,
+  [SupportedChain.Gnosis]: gnosis,
+  [SupportedChain.Base]: base,
+  [SupportedChain.Ethereum]: mainnet,
+};
+
+export const SUPPORTED_CHAIN_ID_MAP: Record<number, SupportedChain> = {
+  11155111: SupportedChain.Sepolia,
+  100: SupportedChain.Gnosis,
+  8453: SupportedChain.Base,
+  1: SupportedChain.Ethereum,
+};
+
+export const CHAIN_NAME_MAP: Record<string, SupportedChain> = {
+  ['ethereum,eth,mainnet']: SupportedChain.Ethereum,
+  ['gnosis,xdai']: SupportedChain.Gnosis,
+  ['base']: SupportedChain.Base,
+  ['sepolia']: SupportedChain.Sepolia,
+};
+
+export const POPULAR_CONTRACTS_MAP: Record<string, ContractConfig> = {
+  USDC: {
+    name: 'USDC',
+    network: SupportedChain.Ethereum,
+    abiHash: '',
+    address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+  },
+  DAI: {
+    name: 'DAI',
+    network: SupportedChain.Ethereum,
+    abiHash: '',
+    address: '0x6b175474e89094c44da98b954eedeac495271d0f',
+  },
+  USDT: {
+    name: 'USDT',
+    network: SupportedChain.Ethereum,
+    abiHash: '',
+    address: '0xdac17f958d2ee523a2206206994597c13d831ec7',
+  },
+  PudgyPenguins: {
+    name: 'PudgyPenguins',
+    network: SupportedChain.Ethereum,
+    abiHash: '',
+    address: '0xbd3531da5cf5857e7cfaa92426877b022e612cf8',
+  },
+  BAYC: {
+    name: 'BAYC',
+    network: SupportedChain.Ethereum,
+    abiHash: '',
+    address: '0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d',
+  },
+};
+
+export const UNIVERSAL_ENS_RESOLVER_ADDRESS =
+  '0xce01f8eee7E479C928F8919abD53E553a36CeF67';
+
+export const RESOLVER_FUNCTION_NAME = 'findResolver';
+
+export const SMART_CONTRACT_PANEL_ID = 'smart-contract-list-view';
+
+export const POPULAR_CONTRACT_NAMES = new Set(
+  Object.keys(POPULAR_CONTRACTS_MAP),
+);

--- a/src/editor/utils/smart-contract/error-helper.ts
+++ b/src/editor/utils/smart-contract/error-helper.ts
@@ -1,0 +1,39 @@
+import type { Hex } from 'viem';
+
+export class ContractNotFound extends Error {
+  constructor(contractName: string) {
+    super(`Contract "${contractName}" not found in registry`);
+  }
+}
+
+export class InvalidFunctionName extends Error {
+  constructor(functionName: string) {
+    super(`Function "${functionName}" not in ABI "`);
+  }
+}
+
+export class ReadOnlyError extends Error {
+  constructor(functionName: string) {
+    super(`Function "${functionName}" is not read‑only`);
+  }
+}
+
+export class InvalidParams extends Error {
+  constructor(message: string) {
+    super(`Invalid Function Params: ${message}`);
+  }
+}
+
+export class UnsupportedChainError extends Error {
+  constructor(chainId: number | Hex | string) {
+    super(`Chain ${chainId} is not supported`);
+  }
+}
+
+export class ContractAbiFetchError extends Error {
+  constructor(contractAddress: string, chainId: number | Hex) {
+    super(
+      `Failed to fetch contract ABI for ${contractAddress} on chain ${chainId}`,
+    );
+  }
+}

--- a/src/editor/utils/smart-contract/helpers.ts
+++ b/src/editor/utils/smart-contract/helpers.ts
@@ -1,0 +1,54 @@
+export function sanitizeValue(value: unknown) {
+  if (typeof value === 'bigint') return value.toString();
+  if (Array.isArray(value)) {
+    return flattenArray(value);
+  }
+  if (isPlainObject(value)) {
+    return [flattenObject(value as Record<string, unknown>)];
+  }
+  return value;
+}
+
+export function flattenArray(arr: unknown[]): unknown[] {
+  const result: Record<string | number, unknown> = {};
+  let allPlainObjects = true;
+
+  for (let i = 0; i < arr.length; i++) {
+    if (Array.isArray(arr[i])) continue;
+    const item = sanitizeValue(arr[i]);
+    const isPlainObject = typeof item === 'object' && item !== null;
+
+    if (!isPlainObject) {
+      allPlainObjects = false;
+      result[`item_${i}`] = item;
+    } else {
+      Object.assign(result, item as Record<string, unknown>);
+    }
+  }
+
+  return allPlainObjects ? arr : [result];
+}
+
+export function flattenObject(
+  obj: Record<string, unknown>,
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(obj)) {
+    if (Array.isArray(val)) {
+      result[key] = flattenArray(val);
+    } else if (isPlainObject(val)) {
+      Object.assign(result, flattenObject(val as Record<string, unknown>));
+    } else {
+      result[key] = sanitizeValue(val);
+    }
+  }
+  return result;
+}
+
+export function isPlainObject(val: unknown): val is Record<string, unknown> {
+  return (
+    typeof val === 'object' &&
+    val !== null &&
+    Object.getPrototypeOf(val) === Object.prototype
+  );
+}

--- a/src/editor/utils/smart-contract/reading-utils.ts
+++ b/src/editor/utils/smart-contract/reading-utils.ts
@@ -1,0 +1,437 @@
+import type { Abi, AbiFunction, AbiParameter, Chain, Hex } from 'viem';
+import {
+  createPublicClient,
+  encodeAbiParameters,
+  fallback,
+  getAbiItem,
+  http,
+  isAddress,
+  toHex,
+} from 'viem';
+import { packetToBytes } from 'viem/ens';
+import type {
+  CallerParams,
+  ContractConfig,
+  ContractRegistry,
+  FetchAbiParams,
+  ParsedFunction,
+  SupportedChain,
+} from '../../types/smart-contract';
+import {
+  CHAIN_NAME_MAP,
+  DEFAULT_RPC_URL_MAP,
+  RESOLVER_FUNCTION_NAME,
+  SUPPORTED_CHAIN_ID_MAP,
+  SUPPORTED_VIEM_CHAIN_MAP,
+  UNIVERSAL_ENS_RESOLVER_ADDRESS,
+} from './constants';
+import {
+  ContractAbiFetchError,
+  ContractNotFound,
+  InvalidFunctionName,
+  InvalidParams,
+  ReadOnlyError,
+  UnsupportedChainError,
+} from './error-helper';
+import { sanitizeValue } from './helpers';
+
+export type SmartContractRuntimeDeps = {
+  resolveAbi?: (abiHash: string) => Promise<Abi>;
+  rpcConfig?: Partial<Record<SupportedChain, string>>;
+  abiCache: Record<string, Abi>;
+};
+
+const getRpcUrls = (
+  network: SupportedChain,
+  rpcConfig?: Partial<Record<SupportedChain, string>>,
+): string[] => {
+  const fromProp = rpcConfig?.[network];
+  if (fromProp) return [fromProp];
+  return DEFAULT_RPC_URL_MAP[network] || [];
+};
+
+const getPublicClient = (chain: Chain, deps: SmartContractRuntimeDeps) => {
+  const network =
+    SUPPORTED_CHAIN_ID_MAP[chain.id as keyof typeof SUPPORTED_CHAIN_ID_MAP];
+  const rpcUrls = network ? getRpcUrls(network, deps.rpcConfig) : [];
+  const transport = fallback(rpcUrls.map((url) => http(url)));
+  return createPublicClient({ transport, chain });
+};
+
+export const getContractConfig = (
+  contractName: string,
+  contractRegistry: ContractRegistry,
+) => {
+  const contractConfig = contractRegistry[contractName];
+  if (!contractConfig) {
+    throw new ContractNotFound(contractName);
+  }
+  return contractConfig;
+};
+
+export const fetchAbi = async (
+  params: FetchAbiParams,
+  deps: SmartContractRuntimeDeps,
+): Promise<Abi> => {
+  const cacheKey = params.ipfsHash
+    ? `${params.contractAddress}_${params.chain.id}_${params.ipfsHash}`
+    : `${params.contractAddress}_${params.chain.id}`;
+
+  if (deps.abiCache[cacheKey]) {
+    return deps.abiCache[cacheKey];
+  }
+
+  let abi: Abi | undefined;
+
+  if (params.ipfsHash && deps.resolveAbi) {
+    abi = await deps.resolveAbi(params.ipfsHash);
+  } else {
+    abi = await fetchVerifiedAbi(params.contractAddress, params.chain);
+  }
+
+  if (!abi) {
+    throw new ContractAbiFetchError(params.contractAddress, params.chain.id);
+  }
+
+  deps.abiCache[cacheKey] = abi;
+  return abi;
+};
+
+export const validateParams = (
+  functionInput: readonly AbiParameter[],
+  args: unknown[],
+) => {
+  try {
+    encodeAbiParameters(functionInput ?? [], args);
+    return true;
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : String(e);
+    throw new InvalidParams(message);
+  }
+};
+
+export const getChainFromChainId = (chainId: number | Hex | string): Chain => {
+  if (isNaN(Number(chainId))) {
+    const chainName = Object.keys(CHAIN_NAME_MAP).find((value) => {
+      const keys = value.split(',');
+      return keys.includes(chainId.toString().toLowerCase().trim());
+    });
+
+    if (!chainName) throw new UnsupportedChainError(chainId);
+
+    return SUPPORTED_VIEM_CHAIN_MAP[
+      CHAIN_NAME_MAP[chainName as keyof typeof CHAIN_NAME_MAP]
+    ];
+  }
+  return SUPPORTED_VIEM_CHAIN_MAP[
+    SUPPORTED_CHAIN_ID_MAP[chainId as keyof typeof SUPPORTED_CHAIN_ID_MAP]
+  ];
+};
+
+export const fetchVerifiedAbi = async (
+  contractAddress: Hex,
+  chain: Chain,
+  exactFields: string[] = ['abi', 'proxyResolution'],
+): Promise<Abi> => {
+  const baseURL = `https://sourcify.dev/server/v2/contract/${chain.id}/${contractAddress?.trim()}?fields=${exactFields.join(',')}`;
+
+  const response = await fetch(baseURL);
+  const data = await response.json();
+
+  if (data?.proxyResolution?.isProxy) {
+    const implementationAddress =
+      data?.proxyResolution?.implementations?.[0]?.address;
+
+    if (!isAddress(implementationAddress)) return data?.abi as Abi;
+
+    return fetchVerifiedAbi(implementationAddress, chain, ['abi']);
+  }
+
+  return data.abi as Abi;
+};
+
+export function parseAbiViewFunctions(abi: Abi): ParsedFunction[] {
+  const result: ParsedFunction[] = [];
+
+  for (const item of abi) {
+    if (
+      item.type !== 'function' ||
+      (item.stateMutability !== 'view' && item.stateMutability !== 'pure')
+    ) {
+      continue;
+    }
+
+    const fn = item as AbiFunction;
+    const inputs = fn.inputs.length
+      ? fn.inputs.map(({ type }) => `[${type}]`).join(', ')
+      : '';
+    const functionName = `${fn.name}${inputs ? `(${inputs})` : '()'}`;
+    const output = fn.outputs?.length
+      ? fn.outputs.map(({ type }) => type).join(', ')
+      : 'void';
+
+    result.push({ functionName, output });
+  }
+
+  return result;
+}
+
+export const getCallerParamsByAddress = async (
+  callSignature: unknown[],
+  deps: SmartContractRuntimeDeps,
+): Promise<CallerParams> => {
+  const [contractAddress, chainId, ...rest] = callSignature as [
+    Hex,
+    string | number,
+    ...unknown[],
+  ];
+
+  if (!chainId) {
+    throw new Error('Chain ID not found');
+  }
+
+  const chain = getChainFromChainId(chainId);
+  const abi = await fetchAbi({ contractAddress, chain }, deps);
+  const [functionName, ...args] = rest;
+
+  return { abi, contractAddress, chain, functionName: functionName as string, args };
+};
+
+export const getCallerParamsByName = async (
+  callSignature: unknown[],
+  registry: ContractRegistry,
+  deps: SmartContractRuntimeDeps,
+): Promise<CallerParams> => {
+  const [contractName, functionName, ...args] = callSignature as [
+    string,
+    string,
+    ...unknown[],
+  ];
+  const contractConfig = getContractConfig(contractName, registry);
+  const chain = SUPPORTED_VIEM_CHAIN_MAP[contractConfig.network];
+
+  const abi = await fetchAbi(
+    {
+      contractAddress: contractConfig.address,
+      chain,
+      ipfsHash: contractConfig.abiHash || undefined,
+    },
+    deps,
+  );
+
+  return {
+    abi,
+    contractAddress: contractConfig.address,
+    chain,
+    args,
+    functionName,
+  };
+};
+
+export const parseCallSignature = async (
+  callSignature: unknown[],
+  registry: ContractRegistry,
+  deps: SmartContractRuntimeDeps,
+): Promise<CallerParams> => {
+  if (!callSignature.length) throw new InvalidParams('Invalid call');
+  const [contractIdentifier] = callSignature;
+
+  if (isAddress(contractIdentifier as string)) {
+    return getCallerParamsByAddress(callSignature, deps);
+  }
+
+  return getCallerParamsByName(callSignature, registry, deps);
+};
+
+export const executeSmartContractCall = async (
+  params: CallerParams,
+  deps: SmartContractRuntimeDeps,
+) => {
+  const { abi, contractAddress, chain, functionName, args } = params;
+
+  if (!functionName) {
+    const parsedResponse = [];
+    for (const item of abi) {
+      if (item.type === 'function') {
+        parsedResponse.push({
+          name: item.name,
+          inputs: item.inputs.map((input) => input.name),
+          stateMutability: item.stateMutability,
+        });
+      }
+    }
+
+    const sortedResponse = parsedResponse.sort((a, b) => {
+      if (a.stateMutability === 'view') return -1;
+      if (b.stateMutability === 'view') return 1;
+      return 0;
+    });
+
+    const dataRows = sortedResponse.map((item) => ({
+      'Function name': item.name,
+      Argument: Array.isArray(item.inputs)
+        ? item.inputs.join(', ')
+        : item.inputs,
+      stateMutability: item.stateMutability,
+    }));
+
+    return {
+      response: dataRows,
+      staticInstructions: [
+        'How to use this response? Use next syntax for SMARTCONTRACT function',
+        'SMARTCONTRACT("contract_address", "functionName", "argument")',
+        'Put a needed function and argument from list below',
+      ],
+    };
+  }
+
+  const abiItem = getAbiItem({ abi, name: functionName }) as AbiFunction;
+  if (!abiItem) throw new InvalidFunctionName(functionName);
+  if (
+    !['view', 'pure'].includes(abiItem.stateMutability) &&
+    !abiItem.constant
+  ) {
+    throw new ReadOnlyError(functionName);
+  }
+
+  validateParams(abiItem.inputs, args ?? []);
+
+  const publicClient = getPublicClient(chain, deps);
+  const result = await publicClient.readContract({
+    abi,
+    address: contractAddress,
+    functionName,
+    args: getArgs(args, contractAddress, functionName),
+  });
+
+  return {
+    response: sanitizeValue(result),
+    outputType: abiItem.outputs,
+  };
+};
+
+const getArgs = (
+  args: unknown[] | undefined,
+  contractAddress: Hex,
+  functionName: string,
+) => {
+  if (!args) return undefined;
+
+  if (
+    functionName === RESOLVER_FUNCTION_NAME &&
+    contractAddress === UNIVERSAL_ENS_RESOLVER_ADDRESS
+  ) {
+    return args.map((arg) => toHex(packetToBytes(arg as string)));
+  }
+
+  return args;
+};
+
+export const validateAbi = (abi: unknown) => {
+  let _abi = abi;
+  if (typeof abi === 'string') {
+    _abi = JSON.parse(abi);
+  }
+  if (!Array.isArray(_abi)) {
+    throw new Error('Invalid ABI');
+  }
+
+  for (const item of _abi) {
+    if (typeof item !== 'object' || !item) {
+      throw new Error('Invalid ABI');
+    }
+    if (!('type' in item) || !item.type) {
+      throw new Error('Invalid ABI');
+    }
+  }
+};
+
+const hasUnquotedHex = (str: string) =>
+  /(^|[\s,[{])0x[0-9a-fA-F]+([\s,\]}]|$)/.test(str);
+
+export const normalizeGridArray = (
+  input: unknown[],
+  functionName: string,
+  abi: Abi,
+) => {
+  return input.map((item, index) => {
+    let result: unknown = item;
+
+    if (
+      typeof result === 'string' &&
+      ((result.startsWith('[') && result.endsWith(']')) ||
+        (result.startsWith('{') && result.endsWith('}')))
+    ) {
+      try {
+        if (hasUnquotedHex(result)) {
+          throw new Error('Invalid JSON: unquoted hex value detected');
+        }
+        let normalized = result.replace(/'/g, '"');
+        normalized = normalized.replace(
+          /([{,]\s*)([a-zA-Z0-9_]+)\s*:/g,
+          '$1"$2":',
+        );
+        result = JSON.parse(normalized);
+      } catch (err: unknown) {
+        if (
+          err instanceof Error &&
+          err.message === 'Invalid JSON: unquoted hex value detected'
+        ) {
+          throw err;
+        }
+      }
+    }
+
+    if (Array.isArray(result)) {
+      if (
+        result.length === 1 &&
+        Array.isArray(result[0]) &&
+        !Array.isArray(result[0][0])
+      ) {
+        result = result[0];
+      } else if (
+        result.every(
+          (row) =>
+            Array.isArray(row) && row.length === 1 && !Array.isArray(row[0]),
+        )
+      ) {
+        result = result.map((row) => (row as unknown[])[0]);
+      }
+    }
+
+    const functionABI = abi.find(
+      (entry) => entry.type === 'function' && entry.name === functionName,
+    ) as AbiFunction | undefined;
+    const isInputArray = functionABI?.inputs?.[index]?.type.includes('[]');
+
+    if (Array.isArray(result) && result.length === 1 && !isInputArray) {
+      return result[0];
+    }
+
+    if (!Array.isArray(result) && isInputArray) {
+      return [result];
+    }
+
+    return result;
+  });
+};
+
+export const fetchContractAbi = (
+  contract: ContractConfig,
+  deps: SmartContractRuntimeDeps,
+) => {
+  const chain = SUPPORTED_VIEM_CHAIN_MAP[contract.network];
+  return fetchAbi(
+    {
+      contractAddress: contract.address,
+      chain,
+      ipfsHash: contract.abiHash || undefined,
+    },
+    deps,
+  );
+};
+
+export const isPopularContract = (
+  name: string,
+  popularNames: Set<string>,
+): boolean => popularNames.has(name);

--- a/src/editor/utils/smart-contract/signature-utils.ts
+++ b/src/editor/utils/smart-contract/signature-utils.ts
@@ -1,0 +1,44 @@
+export function parseFunctionSignature(signature: string) {
+  const fnMatch = signature.match(/^([a-zA-Z_][a-zA-Z0-9_]*)\((.*)\)$/);
+  if (!fnMatch) return null;
+
+  const name = fnMatch[1];
+  const argsPart = fnMatch[2].trim();
+
+  if (!argsPart) {
+    return { name, args: '' };
+  }
+
+  const argsArray = argsPart
+    .split(',')
+    .map((arg) => {
+      const match = arg.trim().match(/^\[(.+)\]$/);
+      const match2 = match?.[1].includes('[')
+        ? `_${match[1]}`
+        : `"_${match?.[1]}"`;
+      return match ? `${match2}` : null;
+    })
+    .filter(Boolean);
+
+  return {
+    name,
+    args: argsArray.join(','),
+  };
+}
+
+export function getFunctionWithArguments(
+  functions: { functionName: string }[],
+): { functionName: string } | null {
+  if (!Array.isArray(functions) || functions.length === 0) {
+    return null;
+  }
+
+  for (const fn of functions) {
+    const match = fn.functionName.match(/\(([^)]*)\)/);
+    if (match && match[1].trim().length > 0) {
+      return fn;
+    }
+  }
+
+  return functions[0];
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,15 @@ export { CommentsContent } from './editor/components/comments/comment-sidebar';
 export { CommentCellUI } from './editor/components/comments/comment-cell-popup';
 export { useEnsStatus } from './editor/components/comments/ens/use-ens-status';
 export type { EnsStatus } from './editor/components/comments/ens/ens-cache';
+export type {
+  SmartContractConfig,
+  SmartContractEvent,
+  SmartContractEventType,
+  ContractConfig,
+  ContractRegistry,
+  NewContractInput,
+} from './editor/types/smart-contract';
+export { SupportedChain } from './editor/types/smart-contract';
 export type { WorkbookInstance } from '@sheet-engine/react';
 export type {
   CollaborationProps,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -49,6 +49,9 @@ export default defineConfig({
         '@fileverse-dev/formulajs',
         '@fileverse-dev/dsheets-templates',
         '@tippyjs/react',
+        'viem',
+        'viem/chains',
+        'viem/ens',
       ],
       output: {
         globals: {


### PR DESCRIPTION
Consumers now wire keystore persistence via the smartContracts prop instead of handleSmartContractQuery and custom sidebar panels.