### PR TITLE
fix: Collab Stale ydoc split bug

### DIFF
--- a/docs/collab-stale-ydoc-split-bug-summary.md
+++ b/docs/collab-stale-ydoc-split-bug-summary.md
@@ -1,0 +1,49 @@
+# Collab share links stuck on loading skeleton — bug summary
+
+**Status:** Fixed on `main` (both `fileverse-dsheet` and `dsheets.new`).
+
+---
+
+## Non-technical summary
+
+When someone shared a live-collaboration link to a spreadsheet, the person opening the link would sometimes see the sheet's title load fine, but the actual spreadsheet grid never appeared — it just showed a loading skeleton forever. No error message, nothing to click, nothing to retry.
+
+**Why it happened:** under a specific timing condition — starting a collaboration session right as an existing sheet's content was still loading — the app ended up tracking two separate, disconnected copies of the sheet internally. One copy kept the owner's real edits; the other, empty copy is what got sent to anyone who joined the session. Joiners received nothing, but nothing told them anything was wrong.
+
+**Who was affected:** only sheets where the owner started a live-collaboration session while the sheet was still loading (e.g., right after opening it, especially on a slow connection). Brand-new sheets were never affected.
+
+**What we fixed:**
+
+1. Fixed the underlying bug so the app can no longer end up with two disconnected copies.
+2. Added a safety check that refuses to start a session with a broken copy, instead of silently going ahead.
+3. Added detection so that if a session is ever found to be broken, the person joining sees a clear error instead of an endless loading screen.
+4. Fixed a couple of places where real errors were happening but getting silently swallowed before they reached the screen.
+5. On the app side, the "Start Collaboration" button and automatic session resume now wait until the sheet has genuinely finished loading before they become available — closing the timing window that caused this in the first place.
+
+**Already-affected sheets:** no manual fix or data recovery needed. The next time the owner opens the sheet (on the updated app) and starts or resumes a session, it self-heals automatically.
+
+---
+
+## Technical summary
+
+### Symptom
+
+Joiner opens a collab invite link (`/sheet/[dsheetId]/share#key=…`): socket auth succeeds, room title decrypts and renders, but the sheet grid never loads — indefinite skeleton, no error surfaced anywhere. Owner sees their own sheet normally (their content is local). Affected every joiner of an affected room, on every attempt.
+
+### Root cause
+
+`useSyncManager` builds its `SyncManager` once and never updates the `Y.Doc` it holds. Separately, `use-editor-sync.tsx`'s main effect destroyed and recreated the `Y.Doc` whenever `enableIndexeddbSync` flipped true — which happens for an **existing** sheet the moment its content arrives after first render. When that happened while a collaboration session was active, `SyncManager` was left bound to the old, destroyed, empty doc, while the live editor (and local edits) moved to a new doc. The session's initial "here's the sheet" broadcast ended up being an empty 2-byte update instead of real content; any real edits made afterward referenced history that was never uploaded. Joiners received either a completely empty document or one with unintegratable dangling changes — either way, permanently stuck.
+
+This only triggered when: the sheet already existed (not new), its content arrived after first paint (e.g. slower network), and collaboration was started before or during that arrival — a race condition, which is why it looked random and correlated with slow loads.
+
+### Fix
+
+1. **Root fix** — split the doc-lifecycle effect from the IndexedDB-persistence effect in `use-editor-sync.tsx`. The document instance is now only created/destroyed on sheet switch, never on sync-status changes — so `SyncManager` can never end up bound to a stale doc again.
+2. **Defense-in-depth** — `SyncManager.connect()`/`handleReconnection()` now refuse to broadcast from a destroyed doc, throwing loudly instead of silently seeding an empty session.
+3. **Detection** — after syncing history, `SyncManager` checks whether the merged document is unexpectedly empty or has unintegrated dangling updates despite the server reporting history existed, and raises a dedicated error instead of declaring sync complete.
+4. **Error surfacing** — fixed a race where a genuine connection error was immediately overwritten by an unrelated internal reset before the UI could render it, and fixed the handshake timeout so a stalled server handshake can no longer hang the connection state forever with no error.
+5. **UX gate (app side)** — the "Start Collaboration" control and automatic session resume now require a real, package-confirmed sync-complete signal, not just "we have content to hand to the editor" — closing the same timing window from the UI side as well.
+
+### Recovery for already-affected sessions
+
+No data migration or manual repair needed. The fix is self-healing: the next time the affected sheet's owner opens it on an updated client and (re)starts or resumes the session, the app broadcasts a genuine full-state update into the same session, and any previously-stranded changes integrate automatically. Every invite link for that session then starts working.

--- a/docs/superpowers/specs/2026-07-09-collab-stale-ydoc-split-design.md
+++ b/docs/superpowers/specs/2026-07-09-collab-stale-ydoc-split-design.md
@@ -1,0 +1,116 @@
+# Design: Fix collab stale-Y.Doc split (share links stuck on loading skeleton)
+
+**Date:** 2026-07-09
+**RCA:** see conversation / `sheets.fileverse.io` case study `ayTRRkn6KV1tcC6pYyvW1M`
+**Repos touched:** `fileverse-dsheet` (package, Fixes 1-4 + small Fix 5 hook), `dsheets.new` (app, Fix 5 gating).
+**Scope:** five fixes — code-level root fix + defenses in the package, plus a UX-level gate in the app. Forced-heal maintenance script explicitly out of scope — poisoned rooms recover organically when their owner revisits on a fixed client.
+
+---
+
+## Problem recap
+
+`useSyncManager` constructs `SyncManager` once and never updates its bound `Y.Doc` (`updateRefs` skips it). `use-editor-sync.tsx`'s main effect destroys/recreates the doc when `enableIndexeddbSync` flips (existing-sheet content arriving after first render), while collab-active rooms suppress the remount that would otherwise fix the binding. Result: `SyncManager` broadcasts/reads a stale, empty doc while the real editor doc gets local edits — joiners receive an unintegratable or empty room, stuck on skeleton, no error surfaced anywhere.
+
+---
+
+## Fix 1 — Kill the split (root fix)
+
+**File:** `src/editor/hooks/use-editor-sync.tsx`
+
+Split the current single effect (deps `[dsheetId, enableIndexeddbSync, isReadOnly]`, lines 109-147) into two:
+
+- **Doc-lifecycle effect** — deps `[dsheetId]` only. Owns `ydocRef.current` create/destroy. Fires on sheet switch or unmount, never on `enableIndexeddbSync`/`isReadOnly` changes.
+- **Persistence effect** — deps `[enableIndexeddbSync, isReadOnly]`. Attaches/detaches `IndexeddbPersistence` on the existing doc (calls `initialiseEditorIndexedDB` / destroys `persistenceRef.current`). Never touches `ydocRef`.
+
+The collab-connect-on-synced logic currently living inside `persistenceRef.current.once('synced', ...)` moves with the persistence effect; behavior unchanged, just no longer coupled to doc recreation.
+
+Host apps that key the editor component on `dsheetId` (e.g. `dsheets.new`'s `key={dsheetId}-...}`) already remount on sheet switch, so the `[dsheetId]` dep on doc-lifecycle is a no-op there — it exists for other/future consumers of the package that might not remount.
+
+---
+
+## Fix 2 — Refuse to broadcast from a destroyed doc (defense-in-depth)
+
+**File:** `src/sync-local/SyncManager.ts`, `connect()` (~line 174) and `handleReconnection()` (~line 407)
+
+Before the initial `Y.encodeStateAsUpdate(this.ydoc)` broadcast, guard:
+
+```
+if (this.ydoc.isDestroyed) {
+  throw new Error('SyncManager: refusing to connect with a destroyed Y.Doc');
+}
+```
+
+Caught by the existing `connect()`/`handleReconnection()` try/catch, which routes to `handleConnectionError` → surfaces via Fix 4's error path instead of silently broadcasting a 2-byte empty state. Makes this whole bug class fail loud if any future code path reintroduces a stale-doc handoff.
+
+---
+
+## Fix 3 — Detect poisoned rooms at the joiner
+
+**File:** `src/sync-local/SyncManager.ts`, `syncLatestCommit()` (~line 555)
+
+After merging and applying history (`Y.applyUpdate(this.ydoc, mergedState, 'self')`, ~line 628), add a post-merge health check, only when the server actually claimed history existed (`history?.data` present or `encryptedUpdates.length > 0` — i.e. don't flag a legitimately brand-new empty sheet):
+
+- `this.ydoc.store.pendingStructs !== null` → dangling deltas referencing a missing base (the case-study room's exact signature).
+- Server claimed content but doc has zero top-level keys after merge (`this.ydoc.share.size === 0`) → complete-but-empty era (the two other confirmed cases).
+
+On either: don't transition to `SYNC_COMPLETE`. Instead raise a new `CollabErrorCode` (e.g. `POISONED_ROOM`) through the existing error path (`handleConnectionError`-equivalent / direct `send({type:'ERROR', ...})`), non-recoverable. Add the code to `CollabErrorCode` in `types.ts` and a friendly message branch in `dsheets.new`'s `use-collab-sheet.ts` `sessionError` memo (something like "This session had a sync problem — ask the sheet owner to reopen it.").
+
+This is observability + fail-loud, not a fix — it turns an invisible infinite skeleton into a visible, reported error, and gives a count of how many existing rooms are still poisoned post-deploy.
+
+---
+
+## Fix 4 — Surface errors that currently get swallowed
+
+**File:** `src/sync-local/SyncManager.ts`, `src/sync-local/socketClient.ts`
+
+Two independent gaps:
+
+**a) ERROR gets clobbered by a stray RESET.** `handleConnectionError` (~line 370) calls `socketClient.disconnect()` before sending `ERROR`. `socketClient.disconnect()` synchronously fires the socket's `'disconnect'` event → `SyncManager.disconnect()` (async) → deferred (via `await`) call to `disconnectInternal()` → `send({type:'RESET'})`. That RESET is a *valid* transition from `error` (intentional, for retry flows) — but it fires on the next microtask, and consumer-facing `collabState` is a live `useMemo`, so the error state gets overwritten before React ever paints it. The `onError` callback itself does fire correctly (confirmed: these errors are reported today) — only the **UI state** is lost.
+
+  Fix: `disconnectInternal()` should not send `RESET` if the current status is already a terminal state reached via an explicit error/termination path in the same call chain (i.e., don't auto-RESET out of `error` as a side effect of cleanup — RESET-from-error should only happen from an explicit user-initiated retry, not from `handleConnectionError`'s own teardown). Concretely: have `handleConnectionError` perform socket teardown without routing back through the public `disconnect()`/`disconnectInternal()` path (which is what triggers the auto-RESET), so the `error` state set by `send({type:'ERROR', ...})` is the last word.
+
+**b) Handshake can hang forever.** `socketClient.ts`'s 30s `connectionTimeout` (~line 420) is cleared on the raw `'connect'` (transport-level) event, not on handshake completion. If the transport connects but the server never emits `/server/handshake`, nothing times out — `SyncManager.connect()` awaits `onHandshakeSuccess` indefinitely, status sits at `connecting` silently.
+
+  Fix: only clear `connectionTimeout` inside `_handleHandShake` (success and `onHandShakeError` branches), not in the raw `'connect'` handler. Keeps the 30s window covering the full connect→handshake sequence instead of just the transport leg.
+
+`hasCollabContentInitialised` wiring (RCA's 4th sub-item) is already correctly passed at `editor-context.tsx:368` on current `main` — no work needed there, dropped from this plan.
+
+---
+
+## Fix 5 — Gate "Start Collaboration" on real content-sync completion (UX-level)
+
+**Files:** `fileverse-dsheet` (`src/editor/dsheet-editor.tsx`, `src/editor/types.ts`), `dsheets.new` (`components/dsheet-editor/dsheet-editor.tsx`, `components/providers/rtc-provider.tsx`)
+
+Belt-and-suspenders on top of Fix 1: even with the split killed, don't let the UI offer collaboration before the package confirms local content is actually synced.
+
+Current gate (`isSheetReadyForCollab`, [dsheet-editor.tsx:317-319](dsheets.new/components/dsheet-editor/dsheet-editor.tsx#L317-L319)) only checks the app's own `DsheetLoadState.READY` — which flips true the instant on-chain/local content resolves. That's the *same* instant `enableIndexeddbSync` latches true in the package (`dsheet-editor.tsx:491-492`) — i.e. today the button unlocks right as the sync race window opens, not after it closes. The app has no visibility into the package's internal `syncStatus` (IndexedDB persistence completion) today — it's package-internal state, never exposed.
+
+**Package side:** add an optional callback prop, e.g. `onContentSyncStatusChange?: (status: 'initializing' | 'syncing' | 'synced' | 'error') => void`, fired from `EditorContent` (`src/editor/dsheet-editor.tsx`) whenever `syncStatus` (already in `editor-context`) changes.
+
+**App side:** `dsheet-editor.tsx` wires the callback into local state (`contentSyncStatus`), then tightens the gate:
+
+```
+const isSheetReadyForCollab =
+  (loadState === DsheetLoadState.READY || loadState === DsheetLoadState.READY_NO_AUTH) &&
+  contentSyncStatus === 'synced';
+```
+
+No new UI needed — `sheetReadyForCollaboration` already drives both the Start-button `disabled` state ([collaboration-popup.tsx:71-74](dsheets.new/components/collaboration-popup/collaboration-popup.tsx#L71-L74)) and the auto-resume-on-mount effect ([rtc-provider.tsx:565](dsheets.new/components/providers/rtc-provider.tsx#L565)). Tightening the one upstream signal fixes both consumers. Optional: adjust the tooltip copy at collaboration-popup.tsx to distinguish "loading sheet content…" from the existing "checking existing collaboration" message, so the disabled state reads accurately.
+
+This fully subsumes RCA's original fix #5 ("gate collab resume on hydration") — same mechanism now covers manual start too, not just resume.
+
+---
+
+## Non-goals
+
+- **No forced-heal maintenance script.** Poisoned rooms recover organically: next time the owner (or any device with full local history) opens the sheet on a client running the fixed bundle and (re)connects collab, `connect()` broadcasts genuine full state into the same room era; Yjs's pending-struct mechanism integrates any dangling deltas automatically. No server or data migration involved. Operator plan: after this ships, ask the owner(s) of known-affected sheets to revisit and restart their session.
+- No changes to `collaboration-server` (relay) — confirmed not at fault, stores/forwards data as received.
+
+---
+
+## Testing
+
+- No existing test runner in `fileverse-dsheet` (`package.json` has no `test` script, no vitest/jest config) — adding one is out of scope here unless the implementation plan decides a unit test for Fix 1/2 is cheap enough to justify introducing minimal test infra.
+- Primary verification: manual repro (Recipe A from the RCA — throttled network, existing sheet, start collab before content settles, join from fresh incognito) before and after the fix, on local dev pointed at the existing dev relay (`wss://dev-collaboration-server-ff60826701cd.herokuapp.com`).
+- Fix 2 and Fix 3 are independently observable: force a stale doc / truncate the mocked history in a manual test and confirm the guard throws / the error surfaces instead of silently proceeding.
+- Fix 5: confirm the Start-Collaboration button/tooltip stays disabled through `syncing`, only enables after `contentSyncStatus === 'synced'` — throttle network to widen the window and observe.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fileverse-dev/dsheet",
-  "version": "2.1.3",
+  "version": "2.1.3-rtc-debug-6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fileverse-dev/dsheet",
-      "version": "2.1.3",
+      "version": "2.1.3-rtc-debug-6",
       "dependencies": {
         "@fileverse-dev/dsheets-templates": "^0.0.29",
         "@fileverse-dev/formulajs": "^4.4.53",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fileverse-dev/dsheet",
-  "version": "2.1.3-rtc-debug-6",
+  "version": "2.1.3-rtc-debug-7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fileverse-dev/dsheet",
-      "version": "2.1.3-rtc-debug-6",
+      "version": "2.1.3-rtc-debug-7",
       "dependencies": {
         "@fileverse-dev/dsheets-templates": "^0.0.29",
         "@fileverse-dev/formulajs": "^4.4.53",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fileverse-dev/dsheet",
   "private": false,
   "description": "DSheet",
-  "version": "2.1.3-rtc-debug-6",
+  "version": "2.1.3-rtc-debug-7",
   "main": "dist/index.es.js",
   "module": "dist/index.es.js",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fileverse-dev/dsheet",
   "private": false,
   "description": "DSheet",
-  "version": "2.1.3",
+  "version": "2.1.3-rtc-debug-6",
   "main": "dist/index.es.js",
   "module": "dist/index.es.js",
   "exports": {

--- a/src/editor/contexts/editor-context.tsx
+++ b/src/editor/contexts/editor-context.tsx
@@ -106,6 +106,9 @@ interface EditorProviderProps {
   enableLiveQuery?: boolean;
   liveQueryRefreshRate?: number;
   dataBlockApiKeyHandler?: DataBlockApiKeyHandlerType;
+  onContentSyncStatusChange?: (
+    status: 'initializing' | 'syncing' | 'synced' | 'error',
+  ) => void;
 }
 
 // Provider component that wraps the app
@@ -130,6 +133,7 @@ export const EditorProvider: React.FC<EditorProviderProps> = ({
   enableLiveQuery,
   liveQueryRefreshRate,
   dataBlockApiKeyHandler,
+  onContentSyncStatusChange,
 }) => {
   const [forceSheetRender, setForceSheetRender] = useState<number>(1);
   const internalEditorRef = useRef<WorkbookInstance | null>(null);
@@ -239,6 +243,11 @@ export const EditorProvider: React.FC<EditorProviderProps> = ({
     collaboration,
     onCollabUpdate,
   );
+
+  // Let host apps gate collab start/resume on real sync completion.
+  useEffect(() => {
+    onContentSyncStatusChange?.(syncStatus);
+  }, [syncStatus, onContentSyncStatusChange]);
 
   // Imperatively update the local collaborator's display name in awareness and
   // re-broadcast so peers see the new name (mirrors ddoc's

--- a/src/editor/dsheet-editor.tsx
+++ b/src/editor/dsheet-editor.tsx
@@ -316,6 +316,7 @@ const SpreadsheetEditor = ({
   liveQueryRefreshRate,
   enableLiveQuery,
   collaboration,
+  onContentSyncStatusChange,
 }: DsheetProps): JSX.Element => {
   const [exportDropdownOpen, setExportDropdownOpen] = useState<boolean>(false);
 
@@ -340,6 +341,7 @@ const SpreadsheetEditor = ({
       liveQueryRefreshRate={liveQueryRefreshRate}
       enableLiveQuery={enableLiveQuery}
       dataBlockApiKeyHandler={dataBlockApiKeyHandler}
+      onContentSyncStatusChange={onContentSyncStatusChange}
     >
       <EditorContent
         commentData={commentData}

--- a/src/editor/hooks/use-editor-data.tsx
+++ b/src/editor/hooks/use-editor-data.tsx
@@ -282,8 +282,18 @@ export const useEditorData = (
     if (dataInitialized.current) return;
 
     try {
+      console.log('[RTC] use-editor-data: reading ydoc.getArray(dsheetId)', {
+        dsheetId,
+        allShareKeys: Array.from(ydocRef.current.share.keys()),
+      });
       const sheetArray = ydocRef.current.getArray(dsheetId);
+      console.log('[RTC] use-editor-data: sheetArray length BEFORE migrate', {
+        length: sheetArray.length,
+      });
       migrateSheetArrayIfNeeded(ydocRef.current, sheetArray);
+      console.log('[RTC] use-editor-data: sheetArray length AFTER migrate', {
+        length: sheetArray.length,
+      });
 
       // @ts-ignore
       const plain = ySheetArrayToPlain(sheetArray as Y.Array<Y.Map>);
@@ -301,6 +311,12 @@ export const useEditorData = (
 
       dataInitialized.current = true;
       setIsDataLoaded(true);
+      console.log(
+        '[RTC] use-editor-data: collab sheet data initialised, setIsDataLoaded(true)',
+        {
+          sheetCount: plain.length,
+        },
+      );
 
       if (setForceSheetRender) {
         setForceSheetRender((prev) => prev + 1);
@@ -657,9 +673,7 @@ export const useEditorData = (
                   }
                 }
                 if (
-                  mapFieldKeys.some((k) =>
-                    SURGICAL_OBJECT_FIELD_KEYS.has(k),
-                  ) ||
+                  mapFieldKeys.some((k) => SURGICAL_OBJECT_FIELD_KEYS.has(k)) ||
                   mapFieldKeys.includes('filter_select')
                 ) {
                   filterUpdates.set(sheetId, { sheetId, sheetMap });
@@ -880,10 +894,9 @@ export const useEditorData = (
       const applyRemoteDataVerification = () => {
         for (const { sheetId, dvMap } of dataVerificationUpdates.values()) {
           try {
-            sheetEditorRef.current?.setSheetDataVerification?.(
-              dvMap.toJSON(),
-              { id: sheetId },
-            );
+            sheetEditorRef.current?.setSheetDataVerification?.(dvMap.toJSON(), {
+              id: sheetId,
+            });
           } catch (error) {
             console.warn(
               '[DSheet] Skipped remote dataVerification apply — workbook not ready',
@@ -979,7 +992,10 @@ export const useEditorData = (
           const plain = ySheetArrayToPlain(sheetArray as any);
           currentDataRef.current = plain;
         } catch (e) {
-          console.error('[DSheet] ySheetArrayToPlain after remote update failed', e);
+          console.error(
+            '[DSheet] ySheetArrayToPlain after remote update failed',
+            e,
+          );
         }
       };
 

--- a/src/editor/hooks/use-editor-sync.tsx
+++ b/src/editor/hooks/use-editor-sync.tsx
@@ -103,14 +103,28 @@ export const useEditorSync = (
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dsheetId]);
 
-  // Main effect: only runs when dsheetId/enableIndexeddbSync/isReadOnly changes.
-  // Does NOT include collabEnabled — starting/stopping collaboration must not
-  // destroy and recreate the ydoc (data loss).
+  // Doc-lifecycle effect: owns ydocRef only. Deps = [dsheetId] deliberately —
+  // recreating the doc on enableIndexeddbSync/isReadOnly changes is what let
+  // SyncManager (bound once, see useSyncManager) end up pointed at a stale,
+  // destroyed doc while the editor kept editing a new one. See collab
+  // stale-Y.Doc-split design doc for the full incident writeup.
   useEffect(() => {
     if (!ydocRef.current) {
       ydocRef.current = new Y.Doc();
     }
 
+    return () => {
+      if (ydocRef.current) {
+        ydocRef.current.destroy();
+        ydocRef.current = null;
+      }
+    };
+  }, [dsheetId]);
+
+  // Persistence effect: attaches/detaches IndexedDB sync on the existing doc.
+  // Never touches ydocRef — that's what keeps doc identity stable across
+  // enableIndexeddbSync/isReadOnly flips (e.g. content arriving post-mount).
+  useEffect(() => {
     if (isReadOnly) {
       setSyncStatus('synced');
       isSyncedRef.current = true;
@@ -138,13 +152,9 @@ export const useEditorSync = (
         persistenceRef.current.destroy();
         persistenceRef.current = null;
       }
-      if (ydocRef.current) {
-        ydocRef.current.destroy();
-        ydocRef.current = null;
-      }
       isSyncedRef.current = false;
     };
-  }, [dsheetId, enableIndexeddbSync, isReadOnly]);
+  }, [dsheetId, enableIndexeddbSync, isReadOnly, initialiseEditorIndexedDB]);
 
   // Separate effect: connect to collab when collaboration is enabled AFTER the
   // ydoc/IDB is already synced (e.g. user clicks "Start Collaboration").

--- a/src/editor/types.ts
+++ b/src/editor/types.ts
@@ -92,6 +92,12 @@ export interface DsheetProps {
   onDataBlockApiResponse?: (dataBlockName: string) => void;
   onDuneChartEmbed?: () => void;
   onSheetCountChange?: (sheetCount: number) => void;
+  /** Fires whenever local content-sync status changes. Host apps should gate
+   * collab start/resume on 'synced' — starting before local content is fully
+   * synced is what let the RTC layer bind to a stale doc in the past. */
+  onContentSyncStatusChange?: (
+    status: 'initializing' | 'syncing' | 'synced' | 'error',
+  ) => void;
   editorStateRef?: React.MutableRefObject<{
     refreshIndexedDB: () => Promise<void>;
   } | null>;

--- a/src/sync-local/SyncManager.ts
+++ b/src/sync-local/SyncManager.ts
@@ -178,8 +178,6 @@ export class SyncManager {
     this.roomKeyBytes = toUint8Array(config.roomKey);
     this.isOwner = config.isOwner;
 
-    const initialUpdate = fromUint8Array(Y.encodeStateAsUpdate(this.ydoc));
-
     this.socketClient = new SocketClient({
       wsUrl: config.wsUrl,
       roomKey: config.roomKey,
@@ -194,6 +192,16 @@ export class SyncManager {
     this.send({ type: 'CONNECT' });
 
     try {
+      // Never broadcast from a destroyed doc — refuse loudly instead of
+      // silently seeding the room with an empty full-state update.
+      if (this.ydoc.isDestroyed) {
+        throw new Error(
+          'SyncManager: refusing to connect with a destroyed Y.Doc',
+        );
+      }
+
+      const initialUpdate = fromUint8Array(Y.encodeStateAsUpdate(this.ydoc));
+
       await this.connectSocket();
       // After successful handshake, transition to syncing
       this.send({ type: 'AUTH_SUCCESS' });
@@ -230,6 +238,20 @@ export class SyncManager {
   async disconnect(): Promise<void> {
     if (this._status === 'idle' || this._status === 'terminated') return;
     await this.awaitFlush();
+    // Re-check after the await: handleConnectionError's own socket teardown
+    // synchronously fires this same disconnect() (via the socket's native
+    // 'disconnect' event) before it has sent ERROR. By the time we resume
+    // here ERROR has already landed — bail instead of clobbering it with a
+    // RESET the consumer never gets to see. Fresh read (not `this._status`
+    // again) so TS doesn't carry over the narrowing from the check above —
+    // the field can change out from under us during the await.
+    const statusAfterFlush = this._status as CollabStatus;
+    if (
+      statusAfterFlush === 'idle' ||
+      statusAfterFlush === 'terminated' ||
+      statusAfterFlush === 'error'
+    )
+      return;
     await this.disconnectInternal();
   }
 
@@ -373,7 +395,9 @@ export class SyncManager {
 
     let collabError: CollabError;
 
-    if (
+    if (errorName === 'PoisonedRoomError') {
+      collabError = createCollabError('POISONED_ROOM', error.message);
+    } else if (
       errorName === 'SocketConnectionTimeoutError' ||
       errorMessage.includes('timed out')
     ) {
@@ -407,6 +431,12 @@ export class SyncManager {
   private async handleReconnection(): Promise<void> {
     try {
       this.send({ type: 'RECONNECTED' });
+
+      if (this.ydoc.isDestroyed) {
+        throw new Error(
+          'SyncManager: refusing to reconnect with a destroyed Y.Doc',
+        );
+      }
 
       const initialUpdate = fromUint8Array(Y.encodeStateAsUpdate(this.ydoc));
       await this.syncLatestCommit(initialUpdate);
@@ -626,6 +656,25 @@ export class SyncManager {
       if (updates.length) {
         const mergedState = Y.mergeUpdates(updates);
         Y.applyUpdate(this.ydoc, mergedState, 'self');
+      }
+
+      // Detect a poisoned room: server had history for this room but the doc
+      // came out empty or with dangling deltas (base structs never arrived —
+      // e.g. an owner session that broadcast from a stale doc). Surface as an
+      // error instead of silently landing on an empty, unrecoverable sheet.
+      const serverClaimedHistory =
+        Boolean(history?.data) ||
+        Boolean(encryptedUpdates && encryptedUpdates.length > 0);
+      if (serverClaimedHistory) {
+        const isDangling = this.ydoc.store.pendingStructs !== null;
+        const isEmptyDespiteHistory = this.ydoc.share.size === 0;
+        if (isDangling || isEmptyDespiteHistory) {
+          const error = new Error(
+            'Room history failed to integrate — base structs missing (poisoned room)',
+          );
+          error.name = 'PoisonedRoomError';
+          throw error;
+        }
       }
 
       this.uncommittedUpdatesIdList = uncommittedChangesId;

--- a/src/sync-local/SyncManager.ts
+++ b/src/sync-local/SyncManager.ts
@@ -603,6 +603,11 @@ export class SyncManager {
       }
 
       const updates: Uint8Array[] = [];
+      // Tracks a failed commit-content fetch/decrypt — a transient storage
+      // problem, not proof the room is poisoned. Gates the poisoned-room
+      // check below so a bad IPFS fetch isn't misreported as "ask the owner
+      // to reopen the sheet" when a retry would likely just work.
+      let commitContentFetchFailed = false;
 
       if (history?.cid && this.servicesRef?.fetchFromStorage) {
         const content = await this.servicesRef.fetchFromStorage(history.cid);
@@ -618,7 +623,10 @@ export class SyncManager {
               'SyncManager: failed to decrypt commit content, skipping',
               err,
             );
+            commitContentFetchFailed = true;
           }
+        } else {
+          commitContentFetchFailed = true;
         }
       }
 
@@ -662,13 +670,29 @@ export class SyncManager {
       // came out empty or with dangling deltas (base structs never arrived —
       // e.g. an owner session that broadcast from a stale doc). Surface as an
       // error instead of silently landing on an empty, unrecoverable sheet.
+      //
+      // store.clients (not share.size) is the "is this doc really empty"
+      // signal — getArray()/getMap() calls elsewhere in the app register a
+      // root type on `share` with zero structs, so `share.size` goes
+      // non-zero on mount regardless of whether any real content exists.
+      // store.clients only grows from actual content operations.
       const serverClaimedHistory =
         Boolean(history?.data) ||
         Boolean(encryptedUpdates && encryptedUpdates.length > 0);
+
       if (serverClaimedHistory) {
         const isDangling = this.ydoc.store.pendingStructs !== null;
-        const isEmptyDespiteHistory = this.ydoc.share.size === 0;
+        const isEmptyDespiteHistory = this.ydoc.store.clients.size === 0;
         if (isDangling || isEmptyDespiteHistory) {
+          if (commitContentFetchFailed) {
+            // Known cause: couldn't retrieve/decrypt the commit snapshot.
+            // Storage/network hiccup, not proof the room itself is broken —
+            // let the normal retry loop run again instead of telling the
+            // user to go bug the owner.
+            throw new Error(
+              'Failed to sync commit content from storage — retry may succeed',
+            );
+          }
           const error = new Error(
             'Room history failed to integrate — base structs missing (poisoned room)',
           );
@@ -1073,6 +1097,11 @@ export class SyncManager {
           `SyncManager: ${label} attempt ${attempt + 1} failed`,
           err,
         );
+
+        // Poisoned-room detection is deterministic against the same server
+        // data — retrying re-fetches and re-decrypts the entire room
+        // history for a result that can't change. Fail fast.
+        if (lastError.name === 'PoisonedRoomError') break;
 
         if (attempt === MAX_RETRIES) break;
 

--- a/src/sync-local/socketClient.ts
+++ b/src/sync-local/socketClient.ts
@@ -360,7 +360,7 @@ export class SocketClient {
         response?.errorCode === ServerErrorCode.APP_MISMATCH
           ? 'This link belongs to a different Fileverse app'
           : (response?.error || 'Unknown error') +
-            `, statusCode: ${response?.statusCode}`;
+          `, statusCode: ${response?.statusCode}`;
       const error = new Error(errorMessage);
       config.onHandShakeError(error, response.statusCode);
       return;
@@ -416,7 +416,7 @@ export class SocketClient {
         transports: ['websocket', 'polling'],
       });
 
-      // Safety net: reject if connection isn't established within 60s
+      // Safety net: reject if connection isn't established within 30s
       const connectionTimeout = setTimeout(() => {
         if (!settled) {
           settled = true;

--- a/src/sync-local/socketClient.ts
+++ b/src/sync-local/socketClient.ts
@@ -430,16 +430,20 @@ export class SocketClient {
       }, 30000);
 
       this._socket.on('connect', () => {
-        if (!settled) {
-          settled = true;
-          clearTimeout(connectionTimeout);
-        }
+        // Transport connected — does NOT mean the server will ever send a
+        // handshake. Timer stays armed until '/server/handshake' actually
+        // arrives, so a stalled handshake still times out instead of hanging
+        // 'connecting' forever.
         this._webSocketStatus = SocketStatusEnum.CONNECTING;
         resolve();
       });
 
       // Server handshake event — triggers auth flow
       this._socket.on('/server/handshake', (message) => {
+        if (!settled) {
+          settled = true;
+          clearTimeout(connectionTimeout);
+        }
         this._handleHandShake(message, config).catch((err) => {
           config.onHandShakeError(err);
         });

--- a/src/sync-local/types/index.ts
+++ b/src/sync-local/types/index.ts
@@ -47,6 +47,7 @@ export type CollabErrorCode =
   | 'AUTH_FAILED'
   | 'SYNC_FAILED'
   | 'TIMEOUT'
+  | 'POISONED_ROOM'
   | 'UNKNOWN';
 
 export type CollabError = {


### PR DESCRIPTION
## Summary
- Root fix: `use-editor-sync.tsx` split the doc-lifecycle effect from the IndexedDB-persistence effect. Previously both were driven by one effect keyed on `[dsheetId, enableIndexeddbSync, isReadOnly]`, so an existing sheet's content arriving after first render (`enableIndexeddbSync` flipping true) destroyed and recreated the `Y.Doc` mid-session. `SyncManager` binds to the doc once and never re-binds, so it kept broadcasting/reading a stale, empty doc while the live editor moved to a new one — joiners got an empty or unintegratable room and hung on the skeleton forever, silently.
- Defense-in-depth: `SyncManager.connect()`/`handleReconnection()` now refuse to broadcast from a destroyed doc.
- Detection: `syncLatestCommit()` now flags a room as poisoned (`POISONED_ROOM` error) when the server reports history but the merged doc comes out empty or has dangling unintegrated updates, instead of silently declaring sync complete.
- Error surfacing: fixed a race where `handleConnectionError`'s own socket teardown synchronously triggered a deferred `RESET` that overwrote the `ERROR` state before the UI ever rendered it. Also fixed the handshake connect timer, which previously cleared on raw transport connect instead of on actual handshake completion, so a stalled server handshake could hang `connecting` forever with no timeout.
- New optional prop `onContentSyncStatusChange` on `DsheetProps`, threaded through `EditorProvider`/`dsheet-editor.tsx`, so host apps can gate collab start on real local-sync completion instead of "we have content to hand to the editor."
- Docs: added full RCA + design doc (`docs/superpowers/specs/2026-07-09-collab-stale-ydoc-split-design.md`) and a bug summary (`docs/collab-stale-ydoc-split-bug-summary.md`, technical + non-technical).