### PR TITLE
compact xlsx imports: format-only cells to cellFormatRanges + dataVerification interning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fileverse-dev/dsheet",
-  "version": "4.0.3",
+  "version": "4.0.3-import-compaction.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fileverse-dev/dsheet",
-      "version": "4.0.3",
+      "version": "4.0.3-import-compaction.2",
       "dependencies": {
         "@fileverse-dev/dsheets-templates": "^0.0.29",
         "@fileverse-dev/formulajs": "^4.4.53",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fileverse-dev/dsheet",
-  "version": "4.0.2",
+  "version": "4.0.3-import-compaction.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fileverse-dev/dsheet",
-      "version": "4.0.2",
+      "version": "4.0.3-import-compaction.0",
       "dependencies": {
         "@fileverse-dev/dsheets-templates": "^0.0.29",
         "@fileverse-dev/formulajs": "^4.4.53",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fileverse-dev/dsheet",
-  "version": "4.0.4-import-compaction.0",
+  "version": "4.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fileverse-dev/dsheet",
-      "version": "4.0.4-import-compaction.0",
+      "version": "4.0.5",
       "dependencies": {
         "@fileverse-dev/dsheets-templates": "^0.0.31",
         "@fileverse-dev/formulajs": "4.4.54",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fileverse-dev/dsheet",
-  "version": "4.0.3-import-compaction.0",
+  "version": "4.0.3-import-compaction.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fileverse-dev/dsheet",
-      "version": "4.0.3-import-compaction.0",
+      "version": "4.0.3-import-compaction.1",
       "dependencies": {
         "@fileverse-dev/dsheets-templates": "^0.0.29",
         "@fileverse-dev/formulajs": "^4.4.53",
@@ -19,6 +19,7 @@
         "@tippyjs/react": "^4.2.6",
         "@ucans/ucans": "^0.12.0",
         "classnames": "^2.5.1",
+        "comlink": "^4.4.2",
         "dayjs": "^1.11.0",
         "exceljs": "^4.4.0",
         "immer": "^9.0.12",
@@ -5544,6 +5545,12 @@
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/comlink": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.4.2.tgz",
+      "integrity": "sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==",
+      "license": "Apache-2.0"
     },
     "node_modules/commander": {
       "version": "8.3.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fileverse-dev/dsheet",
   "private": false,
   "description": "DSheet",
-  "version": "4.0.4-import-compaction.0",
+  "version": "4.0.5",
   "main": "dist/index.es.js",
   "module": "dist/index.es.js",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fileverse-dev/dsheet",
   "private": false,
   "description": "DSheet",
-  "version": "4.0.2",
+  "version": "4.0.3-import-compaction.0",
   "main": "dist/index.es.js",
   "module": "dist/index.es.js",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fileverse-dev/dsheet",
   "private": false,
   "description": "DSheet",
-  "version": "4.0.3-import-compaction.0",
+  "version": "4.0.3-import-compaction.1",
   "main": "dist/index.es.js",
   "module": "dist/index.es.js",
   "exports": {
@@ -69,6 +69,7 @@
     "@tippyjs/react": "^4.2.6",
     "@ucans/ucans": "^0.12.0",
     "classnames": "^2.5.1",
+    "comlink": "^4.4.2",
     "dayjs": "^1.11.0",
     "exceljs": "^4.4.0",
     "immer": "^9.0.12",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fileverse-dev/dsheet",
   "private": false,
   "description": "DSheet",
-  "version": "4.0.3",
+  "version": "4.0.3-import-compaction.2",
   "main": "dist/index.es.js",
   "module": "dist/index.es.js",
   "exports": {

--- a/src/editor/hooks/use-celldata-compaction.ts
+++ b/src/editor/hooks/use-celldata-compaction.ts
@@ -3,10 +3,11 @@ import type { MutableRefObject, RefObject } from 'react';
 import type * as Y from 'yjs';
 import type { WorkbookInstance, Sheet } from '@sheet-engine/react';
 import {
+  buildCompactionRevChange,
   compactInMemorySheets,
-  hasCelldataCompactionCompleted,
-  markCelldataCompactionCompleted,
-  planYdocCelldataCompaction,
+  hasSheetCompactionCompleted,
+  markCompactionRevInMemory,
+  planYdocCompaction,
 } from '../utils/compact-committed-celldata';
 import { updateYdocSheetData } from '../utils/update-ydoc';
 import { applyCellFormatRangesCommits } from '../../sheet-engine/core/utils/mirror-cell-format-ranges';
@@ -32,7 +33,7 @@ type UseCelldataCompactionArgs = {
 async function applyCompactionChangesInChunks(
   ydoc: Y.Doc,
   dsheetId: string,
-  changes: ReturnType<typeof planYdocCelldataCompaction>['changes'],
+  changes: ReturnType<typeof planYdocCompaction>['changes'],
   handleOnChangePortalUpdate: () => void,
   isCancelled: () => boolean,
   sheetEditorRef: RefObject<WorkbookInstance | null>,
@@ -66,9 +67,8 @@ async function applyCompactionChangesInChunks(
 }
 
 /**
- * One-shot background compaction: remove committed celldata entries that copy/paste
- * would never write (`shouldPersistCelldataCell` === false). Runs once per dsheetId
- * after the editor is synced and idle so it does not compete with load or edits.
+ * One-shot background compaction (celldata + borderInfo). Completion is stored
+ * on the anchor sheet's config in Yjs so it syncs across devices.
  */
 export function useCelldataCompaction({
   dsheetId,
@@ -87,7 +87,9 @@ export function useCelldataCompaction({
   useEffect(() => {
     if (!dsheetId || isReadOnly) return;
     if (syncStatus !== 'synced' || !isDataLoaded) return;
-    if (hasCelldataCompactionCompleted(dsheetId)) return;
+
+    const ydoc = ydocRef.current;
+    if (!ydoc || hasSheetCompactionCompleted(ydoc, dsheetId)) return;
     if (runningRef.current) return;
 
     let cancelled = false;
@@ -100,8 +102,8 @@ export function useCelldataCompaction({
       if (cancelled || runningRef.current) return;
       if (remoteUpdateRef.current || collabSyncing) return;
 
-      const ydoc = ydocRef.current;
-      if (!ydoc) return;
+      const liveYdoc = ydocRef.current;
+      if (!liveYdoc || hasSheetCompactionCompleted(liveYdoc, dsheetId)) return;
 
       runningRef.current = true;
 
@@ -109,41 +111,36 @@ export function useCelldataCompaction({
         try {
           if (isCancelled() || remoteUpdateRef.current) return;
 
-          const plan = planYdocCelldataCompaction(ydoc, dsheetId);
-          const clearedInMemory = compactInMemorySheets(currentDataRef.current);
+          const plan = planYdocCompaction(liveYdoc, dsheetId);
+          const revChange = buildCompactionRevChange(liveYdoc, dsheetId);
+          const changes = revChange
+            ? [...plan.changes, revChange]
+            : plan.changes;
 
-          if (plan.changes.length > 0) {
-            await applyCompactionChangesInChunks(
-              ydoc,
-              dsheetId,
-              plan.changes,
-              handleOnChangePortalUpdate,
-              isCancelled,
-              sheetEditorRef,
-            );
-          } else if (clearedInMemory > 0) {
-            handleOnChangePortalUpdate();
-          }
+          if (changes.length === 0) return;
 
-          if (
-            !isCancelled() &&
-            (plan.removedFromYdoc > 0 || clearedInMemory > 0)
-          ) {
-            const ctx = sheetEditorRef.current?.getWorkbookContext?.() as
-              | { luckysheetfile?: Sheet[] }
-              | undefined;
-            if (ctx?.luckysheetfile) {
-              compactInMemorySheets(ctx.luckysheetfile);
-            }
-          }
+          compactInMemorySheets(currentDataRef.current);
 
-          // Only flag done if we finished. Cancel mid-chunks would leave ghosts
-          // permanently uncleanable in this browser if we marked anyway.
-          if (!isCancelled()) {
-            markCelldataCompactionCompleted(dsheetId);
+          await applyCompactionChangesInChunks(
+            liveYdoc,
+            dsheetId,
+            changes,
+            handleOnChangePortalUpdate,
+            isCancelled,
+            sheetEditorRef,
+          );
+
+          if (isCancelled()) return;
+
+          markCompactionRevInMemory(currentDataRef.current);
+          const workbook = sheetEditorRef.current?.getWorkbookContext?.()
+            ?.luckysheetfile;
+          if (workbook) {
+            compactInMemorySheets(workbook);
+            markCompactionRevInMemory(workbook);
           }
         } catch (err) {
-          console.warn('[DSheet] Celldata compaction failed:', err);
+          console.warn('[DSheet] Compaction failed:', err);
         } finally {
           runningRef.current = false;
         }

--- a/src/editor/hooks/use-xlsx-import-impl.tsx
+++ b/src/editor/hooks/use-xlsx-import-impl.tsx
@@ -1,58 +1,23 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type React from 'react';
-import SSF from 'ssf';
 import * as Y from 'yjs';
 import { Sheet, WorkbookInstance } from '@sheet-engine/react';
 import { migrateSheetFactoryForImport } from '../utils/migrate-new-yjs';
-import {
-  compactImportedSheetFormatting,
-  internImportedDataVerification,
-} from '../utils/import-compaction';
 import { ySheetArrayToPlain } from '../utils/update-ydoc';
-
-import type { RawSheetImage } from '../utils/xlsx-image-utils';
+import {
+  parseXlsxWorkbook,
+  type XlsxImportWarning,
+  type XlsxParsedWorkbook,
+  type XlsxParseSettings,
+} from '../utils/xlsx-import-pipeline';
+import {
+  isDsheetWorkerSupported,
+  runDsheetWorkerTask,
+} from '../../worker/dsheet-worker-client';
 import { removeFileExtension } from '../utils/export-filename';
-import { normalizeImportedHyperlinkCellV } from '../utils/xlsx-hyperlink-inline';
 import { toast } from '@fileverse/ui';
 
-/** Predefined option colors for data validation dropdowns (when XLSX has no color). */
-const DATA_VERIFICATION_OPTION_COLORS = [
-  '228, 232, 237', // Light Gray
-  '219, 233, 236', // White
-  '244, 217, 227', // Pink
-  '247, 229, 207', // Peach
-  '217, 234, 244', // Blue
-  '222, 239, 222', // Green
-  '239, 239, 239', // Light Green
-  '244, 230, 230', // Rose
-  '247, 239, 217', // Yellow
-  '230, 230, 244', // Purple
-  '217, 244, 244', // Cyan
-  '244, 239, 234', // Cream
-];
-const DEFAULT_OPTION_COLOR = DATA_VERIFICATION_OPTION_COLORS[0]; // Light Gray
-
-const CHECKBOX_PAIRS: [string, string][] = [
-  ['true', 'false'],
-  ['yes', 'no'],
-  ['1', '0'],
-];
-
-function isCheckboxPair(a: string, b: string): boolean {
-  const la = a.toLowerCase();
-  const lb = b.toLowerCase();
-  return CHECKBOX_PAIRS.some(([x, y]) => la === x && lb === y);
-}
-
 const POST_IMPORT_RECALC_MAX_FRAMES = 200;
-
-function generateImportSheetId(): string {
-  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
-    return crypto.randomUUID();
-  }
-
-  return `sheet-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-}
 
 function makeUniqueSheetName(name: string, usedNames: Set<string>): string {
   if (!usedNames.has(name)) return name;
@@ -63,17 +28,6 @@ function makeUniqueSheetName(name: string, usedNames: Set<string>): string {
     candidate = `${name} (${counter})`;
   }
   return candidate;
-}
-
-function richTextRunsToPlainText(ctS: unknown): string | null {
-  if (!Array.isArray(ctS) || ctS.length === 0) return null;
-  const text = ctS.map((seg) => String((seg as any)?.v ?? '')).join('');
-  const trimmed = text.trim();
-  return trimmed ? text : null;
-}
-
-function excelishBooleanText(v: boolean): 'TRUE' | 'FALSE' {
-  return v ? 'TRUE' : 'FALSE';
 }
 
 /**
@@ -125,515 +79,6 @@ function schedulePostImportFormulaRecalc(
   }
 }
 
-/** Build dataVerification color string from option count: use color list only when options ≤ 12; if more, use only grey (first) repeated. */
-function buildDataVerificationColor(optionCount: number): string {
-  if (optionCount <= 0) return DEFAULT_OPTION_COLOR;
-  if (optionCount > DATA_VERIFICATION_OPTION_COLORS.length) {
-    return Array(optionCount).fill(DEFAULT_OPTION_COLOR).join(', ');
-  }
-  return DATA_VERIFICATION_OPTION_COLORS.slice(0, optionCount).join(', ');
-}
-
-/** Parse Excel A1-style address to 0-based row and column. e.g. "A1" -> { row: 0, col: 0 }, "B10" -> { row: 9, col: 1 } */
-function parseA1Address(address: string): { row: number; col: number } | null {
-  const match = address.match(/^([A-Z]+)(\d+)$/i);
-  if (!match) return null;
-  const letters = match[1].toUpperCase();
-  const digits = match[2];
-  let col1Based = 0;
-  for (let i = 0; i < letters.length; i++) {
-    col1Based = col1Based * 26 + (letters.charCodeAt(i) - 64);
-  }
-  const row = parseInt(digits, 10) - 1;
-  const col = col1Based - 1;
-  return { row, col };
-}
-
-/** Map ExcelJS DataValidation to project dataVerification entry (row_column key format) */
-function excelDataValidationToSheetEntry(
-  address: string,
-  dv: {
-    type?: string;
-    formulae?: any[];
-    prompt?: string;
-    showInputMessage?: boolean;
-    allowBlank?: boolean;
-  },
-): { rowColKey: string; entry: Record<string, unknown> } | null {
-  const parsed = parseA1Address(address);
-  if (!parsed) return null;
-  const { row, col } = parsed;
-  const rowColKey = `${row}_${col}`;
-
-  const rawFormula =
-    Array.isArray(dv.formulae) && dv.formulae.length > 0
-      ? String(dv.formulae[0])
-          .replace(/^["']|["']$/g, '')
-          .replace(/["']/g, '')
-      : '';
-  const parts = rawFormula
-    .split(',')
-    .map((s: string) => s.trim())
-    .filter(Boolean);
-
-  let type = dv.type === 'list' ? 'dropdown' : dv.type || 'dropdown';
-  let value1 = rawFormula;
-  let value2 = '';
-
-  if (
-    dv.type === 'list' &&
-    parts.length === 2 &&
-    isCheckboxPair(parts[0], parts[1])
-  ) {
-    type = 'checkbox';
-    value1 = parts[0];
-    value2 = parts[1];
-  }
-
-  // When no color is preset (e.g. from XLSX): one color per option; use predefined list up to 12, then Light Gray for the rest
-  const optionCount =
-    type === 'checkbox' ? 1 : value1 ? value1.split(',').length : 0;
-  const color = buildDataVerificationColor(optionCount || 1);
-
-  const entry: Record<string, unknown> = {
-    type,
-    type2: '',
-    rangeTxt: address,
-    value1,
-    value2,
-    validity: '',
-    remote: false,
-    prohibitInput: dv.type === 'list',
-    hintShow: Boolean(dv.showInputMessage),
-    hintValue: dv.prompt ?? '',
-    color,
-    checked: false,
-  };
-  return { rowColKey, entry };
-}
-
-/** Parse Excel range ref (e.g. "A1:A500" or "A1") to 0-based row/column ranges */
-function parseRefToRange(
-  ref: string,
-): { row: [number, number]; column: [number, number] } | null {
-  const parts = ref.split(':');
-  const start = parseA1Address(parts[0].trim());
-  if (!start) return null;
-  const end = parts.length > 1 ? parseA1Address(parts[1].trim()) : start;
-  if (!end) return null;
-  return {
-    row: [Math.min(start.row, end.row), Math.max(start.row, end.row)],
-    column: [Math.min(start.col, end.col), Math.max(start.col, end.col)],
-  };
-}
-
-/** Parse one or more Excel refs separated by space/comma into 0-based ranges. */
-function parseRefToRanges(
-  ref: string,
-): { row: [number, number]; column: [number, number] }[] {
-  return String(ref || '')
-    .split(/[,\s]+/)
-    .map((x) => x.trim())
-    .filter(Boolean)
-    .map((part) => parseRefToRange(part))
-    .filter(
-      (r): r is { row: [number, number]; column: [number, number] } => !!r,
-    );
-}
-
-/** Build project cellrange from one or more refs (row/column 0-based). */
-function buildCellrange(ref: string): unknown[] | null {
-  const ranges = parseRefToRanges(ref);
-  if (!ranges.length) return null;
-  return ranges.map((range) => {
-    const [r0, r1] = range.row;
-    const [c0, c1] = range.column;
-    return {
-      left: 0,
-      width: 104,
-      top: 0,
-      height: 23,
-      left_move: 0,
-      width_move: 104,
-      top_move: 0,
-      height_move: 11999,
-      row: [r0, r1],
-      column: [c0, c1],
-      row_focus: r0,
-      column_focus: c0,
-      column_select: true,
-    };
-  });
-}
-
-/** Map ExcelJS dxf style to project format (textColor, cellColor, bold, italic, underline, strikethrough) */
-function dxfStyleToFormat(style: {
-  font?: {
-    color?: { argb?: string };
-    bold?: boolean;
-    italic?: boolean;
-    underline?: boolean;
-  } | null;
-  fill?: {
-    type?: string;
-    pattern?: string;
-    fgColor?: { argb?: string };
-  } | null;
-}): {
-  textColor: string;
-  cellColor: string;
-  bold: boolean;
-  italic: boolean;
-  underline: boolean;
-  strikethrough: boolean;
-} {
-  const defaultFormat = {
-    textColor: '#000000',
-    cellColor: '#ffffff',
-    bold: false,
-    italic: false,
-    underline: false,
-    strikethrough: false,
-  };
-  if (!style) return defaultFormat;
-  const font = style.font;
-  const fill = style.fill;
-  let textColor = defaultFormat.textColor;
-  let cellColor = defaultFormat.cellColor;
-  if (font?.color?.argb) {
-    const a = font.color.argb;
-    textColor = '#' + (a.length >= 6 ? a.slice(-6) : a);
-  }
-  if (
-    fill?.type === 'pattern' &&
-    fill.pattern === 'solid' &&
-    fill.fgColor?.argb
-  ) {
-    const a = fill.fgColor.argb;
-    cellColor = '#' + (a.length >= 6 ? a.slice(-6) : a);
-  }
-  return {
-    textColor,
-    cellColor,
-    bold: Boolean(font?.bold),
-    italic: Boolean(font?.italic),
-    underline: Boolean(font?.underline),
-    strikethrough: false,
-  };
-}
-
-/**
- * Extract the text argument from a SEARCH(...) formula (Google/Excel "text contains").
- * Handles Google's SEARCH(("ab"),(C1)) and standard SEARCH("ab",A1). One regex pass, no loops.
- */
-function extractTextFromSearchFormula(formula: string | undefined): string {
-  if (!formula || typeof formula !== 'string') return '';
-  const s = formula
-    .trim()
-    .replace(/&quot;/g, '"')
-    .replace(/&apos;/g, "'")
-    .replace(/&amp;/g, '&')
-    .replace(/^=/, '');
-  // SEARCH(("text"), or SEARCH("text", or SEARCH( ( "text" ) , – allow optional parens/spaces before first quote
-  const m = s.match(/(?:^|[^A-Z])SEARCH\s*\([\s(]*"((?:[^"]|"")*)"/i);
-  if (m) return (m[1] ?? '').replace(/""/g, '"');
-  const m2 = s.match(/(?:^|[^A-Z])SEARCH\s*\([\s(]*'([^']*)'/i);
-  if (m2) return m2[1] ?? '';
-  return '';
-}
-
-/** Fallback: extract first quoted string from a formula (supports "" escaping). */
-function extractFirstQuotedText(formula: string | undefined): string {
-  if (!formula || typeof formula !== 'string') return '';
-  const s = formula
-    .trim()
-    .replace(/&quot;/g, '"')
-    .replace(/&apos;/g, "'")
-    .replace(/^=/, '');
-  const m = s.match(/"((?:[^"]|"")*)"/);
-  if (m) return (m[1] ?? '').replace(/""/g, '"');
-  const m2 = s.match(/'([^']*)'/);
-  if (m2) return m2[1] ?? '';
-  return '';
-}
-
-/**
- * Google Sheets often stores text CF as expression formulas.
- * Detect and map common text-oriented expressions to project condition names.
- */
-function mapExpressionTextCf(
-  formula: string | undefined,
-): { conditionName: string; conditionValue: string[] } | null {
-  if (!formula || typeof formula !== 'string') return null;
-  const f = formula.trim().toUpperCase();
-  const text =
-    extractTextFromSearchFormula(formula) || extractFirstQuotedText(formula);
-  if (!text) return null;
-
-  // contains / not contains
-  if (f.includes('SEARCH(')) {
-    if (f.includes('ISERROR(SEARCH(') || f.includes('NOTNUMBER(SEARCH(')) {
-      return { conditionName: 'textDoesNotContain', conditionValue: [text] };
-    }
-    return { conditionName: 'textContains', conditionValue: [text] };
-  }
-  // starts with
-  if (f.includes('LEFT(')) {
-    return { conditionName: 'textStartsWith', conditionValue: [text] };
-  }
-  // ends with
-  if (f.includes('RIGHT(')) {
-    return { conditionName: 'textEndsWith', conditionValue: [text] };
-  }
-  // exact text check
-  if (f.includes('EXACT(') || f.includes('="')) {
-    return { conditionName: 'textExactly', conditionValue: [text] };
-  }
-  return null;
-}
-
-/** Map ExcelJS cfRule type/operator to project conditionName; return null if unsupported */
-function excelCfTypeToConditionName(
-  type: string,
-  operator?: string,
-  opts?: {
-    percent?: boolean;
-    bottom?: boolean;
-    rank?: number;
-    aboveAverage?: boolean;
-    text?: string;
-    timePeriod?: string;
-  },
-): { conditionName: string; conditionValue: string[] } | null {
-  const t = (type || '').toLowerCase();
-  if (t === 'cellis') {
-    const op = (operator || '').toLowerCase();
-    if (op === 'greaterthan')
-      return { conditionName: 'greaterThan', conditionValue: [] };
-    if (op === 'greaterthanorequal')
-      return { conditionName: 'greaterThanOrEqual', conditionValue: [] };
-    if (op === 'lessthan')
-      return { conditionName: 'lessThan', conditionValue: [] };
-    if (op === 'lessthanorequal')
-      return { conditionName: 'lessThanOrEqual', conditionValue: [] };
-    if (op === 'equal') return { conditionName: 'equal', conditionValue: [] };
-    if (op === 'notequal')
-      return { conditionName: 'notEqual', conditionValue: [] };
-    if (op === 'between')
-      return { conditionName: 'between', conditionValue: [] };
-    if (op === 'notbetween')
-      return { conditionName: 'notBetween', conditionValue: [] };
-    return null;
-  }
-  if (
-    t === 'containstext' ||
-    t === 'notcontainstext' ||
-    t === 'beginswith' ||
-    t === 'endswith' ||
-    t === 'containsblanks' ||
-    t === 'notcontainsblanks'
-  ) {
-    const op = (operator ?? '').toLowerCase();
-    if (t === 'containsblanks' || op === 'containsblanks')
-      return { conditionName: 'empty', conditionValue: [''] };
-    if (t === 'notcontainsblanks' || op === 'notcontainsblanks')
-      return { conditionName: 'notEmpty', conditionValue: [''] };
-    if (
-      t === 'notcontainstext' ||
-      op === 'notcontainstext' ||
-      op === 'notcontains'
-    )
-      return { conditionName: 'textDoesNotContain', conditionValue: [] };
-    if (t === 'beginswith' || op === 'beginswith')
-      return { conditionName: 'textStartsWith', conditionValue: [] };
-    if (t === 'endswith' || op === 'endswith')
-      return { conditionName: 'textEndsWith', conditionValue: [] };
-    if (op === 'equal')
-      return { conditionName: 'textExactly', conditionValue: [] };
-    const text = opts?.text ?? '';
-    return {
-      conditionName: 'textContains',
-      conditionValue: text ? [text] : [],
-    };
-  }
-  if (t === 'duplicatevalues')
-    return { conditionName: 'duplicateValue', conditionValue: ['0'] };
-  if (t === 'uniquevalues')
-    return { conditionName: 'duplicateValue', conditionValue: ['1'] };
-  if (t === 'top10') {
-    const rank = opts?.rank ?? 10;
-    if (opts?.percent && opts?.bottom)
-      return {
-        conditionName: 'last10_percent',
-        conditionValue: [String(rank)],
-      };
-    if (opts?.percent)
-      return { conditionName: 'top10_percent', conditionValue: [String(rank)] };
-    if (opts?.bottom)
-      return { conditionName: 'last10', conditionValue: [String(rank)] };
-    return { conditionName: 'top10', conditionValue: [String(rank)] };
-  }
-  if (t === 'aboveaverage') {
-    if (opts?.aboveAverage === false)
-      return { conditionName: 'belowAverage', conditionValue: [] };
-    return { conditionName: 'aboveAverage', conditionValue: [] };
-  }
-  if (t === 'timeperiod') {
-    const tp = (opts?.timePeriod ?? '').toLowerCase();
-    if (tp === 'today' || tp === 'tomorrow' || tp === 'yesterday') {
-      return {
-        conditionName: 'dateIs',
-        conditionValue: [`preset:${tp}`, '', 'DD/MM/YYYY'],
-      };
-    }
-    if (tp === 'last7days') {
-      return {
-        conditionName: 'dateIs',
-        conditionValue: ['preset:pastWeek', '', 'DD/MM/YYYY'],
-      };
-    }
-    if (tp === 'lastmonth') {
-      return {
-        conditionName: 'dateIs',
-        conditionValue: ['preset:pastMonth', '', 'DD/MM/YYYY'],
-      };
-    }
-    if (tp === 'lastyear') {
-      return {
-        conditionName: 'dateIs',
-        conditionValue: ['preset:pastYear', '', 'DD/MM/YYYY'],
-      };
-    }
-    return null;
-  }
-  return null;
-}
-
-/** One ExcelJS conditional format rule -> one luckysheet_conditionformat_save entry, or null if unsupported */
-function excelCfRuleToLuckysheet(
-  ref: string,
-  rule: {
-    type?: string;
-    operator?: string;
-    formulae?: string[];
-    style?: Record<string, unknown>;
-    text?: string;
-    timePeriod?: string;
-    percent?: boolean;
-    bottom?: boolean;
-    rank?: number;
-    aboveAverage?: boolean;
-  },
-): Record<string, unknown> | null {
-  if (!rule.type) return null;
-
-  // Text CF: Google often puts text only in formulae and leaves `text` empty.
-  let resolvedText = (rule.text ?? '').trim();
-  const firstFormula =
-    Array.isArray(rule.formulae) && rule.formulae[0]
-      ? String(rule.formulae[0])
-      : undefined;
-
-  // Google may export text CF as expression formulas; detect these before enum mapping.
-  const expressionMapped =
-    (rule.type.toLowerCase() === 'expression' ||
-      rule.type.toLowerCase() === 'customformula') &&
-    mapExpressionTextCf(firstFormula);
-  if (expressionMapped) {
-    const cellrange = buildCellrange(ref);
-    if (!cellrange) return null;
-    const format = dxfStyleToFormat(rule.style as any);
-    return {
-      type: 'default',
-      cellrange,
-      format: {
-        textColor: format.textColor,
-        cellColor: format.cellColor,
-        bold: format.bold,
-        italic: format.italic,
-        underline: format.underline,
-        strikethrough: format.strikethrough,
-      },
-      conditionName: expressionMapped.conditionName,
-      conditionRange: [],
-      conditionValue: expressionMapped.conditionValue,
-    };
-  }
-
-  if (
-    (rule.type === 'containsText' ||
-      rule.type === 'notContainsText' ||
-      rule.type === 'beginsWith' ||
-      rule.type === 'endsWith') &&
-    !resolvedText
-  ) {
-    resolvedText = extractTextFromSearchFormula(firstFormula);
-    if (!resolvedText) {
-      resolvedText = extractFirstQuotedText(firstFormula);
-    }
-  }
-
-  const mapped = excelCfTypeToConditionName(rule.type, rule.operator, {
-    percent: rule.percent,
-    bottom: rule.bottom,
-    rank: rule.rank,
-    aboveAverage: rule.aboveAverage,
-    text: resolvedText || rule.text,
-    timePeriod: rule.timePeriod,
-  });
-  if (!mapped) return null;
-
-  let conditionValue: string[];
-  if (
-    rule.type === 'cellIs' &&
-    Array.isArray(rule.formulae) &&
-    rule.formulae.length > 0
-  ) {
-    conditionValue = rule.formulae.map((f) => String(f ?? ''));
-  } else if (
-    mapped.conditionName === 'empty' ||
-    mapped.conditionName === 'notEmpty'
-  ) {
-    conditionValue = [''];
-  } else if (
-    rule.type === 'containsText' ||
-    rule.type === 'notContainsText' ||
-    rule.type === 'beginsWith' ||
-    rule.type === 'endsWith'
-  ) {
-    conditionValue = resolvedText
-      ? [resolvedText]
-      : extractFirstQuotedText(firstFormula)
-        ? [extractFirstQuotedText(firstFormula)]
-        : [];
-  } else {
-    conditionValue = mapped.conditionValue.map((v) =>
-      v == null ? '' : String(v),
-    );
-  }
-
-  const cellrange = buildCellrange(ref);
-  if (!cellrange) return null;
-
-  const format = dxfStyleToFormat(rule.style as any);
-
-  return {
-    type: 'default',
-    cellrange,
-    format: {
-      textColor: format.textColor,
-      cellColor: format.cellColor,
-      bold: format.bold,
-      italic: format.italic,
-      underline: format.underline,
-      strikethrough: format.strikethrough,
-    },
-    conditionName: mapped.conditionName,
-    conditionRange: [],
-    conditionValue,
-  };
-}
-
 export type XlsxImportRuntimeDeps = {
   sheetEditorRef: React.RefObject<WorkbookInstance | null>;
   ydocRef: React.RefObject<Y.Doc | null>;
@@ -653,6 +98,72 @@ export type XlsxImportOptions = {
   generateSheetId?: () => string;
 };
 
+function replayImportWarnings(
+  warnings: XlsxImportWarning[],
+  {
+    filterToastShown,
+    setFilterToastShown,
+  }: Pick<XlsxImportRuntimeDeps, 'filterToastShown' | 'setFilterToastShown'>,
+  options?: XlsxImportOptions,
+): void {
+  for (const warning of warnings) {
+    if (warning.code === 'tables-unsupported') {
+      options?.onWarning?.(
+        'Tables are not fully supported. Table styles will not be applied.',
+      );
+      if (!options?.suppressUiWarnings) {
+        toast({
+          title: 'Tables are not fully supported',
+          description: 'Table styles will not be applied',
+          variant: 'warning',
+          showCloseButton: true,
+          duration: 40 * 1000,
+        });
+      }
+    } else if (warning.code === 'filters-unsupported') {
+      options?.onWarning?.('Filters are not supported in imported files.');
+      if (!filterToastShown) {
+        setFilterToastShown(true);
+        if (!options?.suppressUiWarnings) {
+          toast({
+            title: 'Filters are not supported in imported files',
+            variant: 'warning',
+            showCloseButton: true,
+            duration: 30 * 1000,
+          });
+        }
+      }
+    }
+  }
+}
+
+/**
+ * The pipeline assigns default sheet ids; when the caller supplies a custom
+ * generator (options or workbook settings — same precedence as before the
+ * worker split), swap the generated ids and keep calcChain in sync.
+ */
+function remapGeneratedSheetIds(
+  parsed: XlsxParsedWorkbook,
+  sheetEditorRef: React.RefObject<WorkbookInstance | null>,
+  options?: XlsxImportOptions,
+): void {
+  if (parsed.generatedSheetIds.length === 0) return;
+  const generateCustomId = (): string | undefined =>
+    options?.generateSheetId?.() ??
+    sheetEditorRef.current?.getSettings().generateSheetId();
+  const generatedIds = new Set(parsed.generatedSheetIds);
+  for (const sheet of parsed.sheets) {
+    if (!sheet.id || !generatedIds.has(sheet.id)) continue;
+    const newId = generateCustomId();
+    if (!newId || newId === sheet.id) continue;
+    const oldId = sheet.id;
+    sheet.id = newId;
+    sheet.calcChain?.forEach((entry: { id?: string }) => {
+      if (entry.id === oldId) entry.id = newId;
+    });
+  }
+}
+
 /** Full XLSX import pipeline; loaded only when user imports a file. */
 export async function runXlsxFileUpload(
   {
@@ -671,773 +182,126 @@ export async function runXlsxFileUpload(
   importType?: 'new-dsheet' | 'merge-current-dsheet' | 'new-current-dsheet',
   options?: XlsxImportOptions,
 ): Promise<void> {
-    const input = event?.target;
-    if (!input?.files?.length && !fileArg) {
-      return Promise.resolve();
+  const input = event?.target;
+  if (!input?.files?.length && !fileArg) {
+    return;
+  }
+  const file = input?.files?.[0] || fileArg;
+
+  const workbookSettings = sheetEditorRef.current?.getSettings?.();
+  const parseSettings: XlsxParseSettings = {
+    workbookDefaultColWidth:
+      Number(workbookSettings?.defaultColWidth) || undefined,
+    workbookDefaultRowHeight:
+      Number(workbookSettings?.defaultRowHeight) || undefined,
+  };
+
+  let parsed: XlsxParsedWorkbook | null = null;
+  try {
+    // Parse + decorate + compact off the main thread; the UI stays
+    // interactive during the multi-second exceljs/luckyexcel work.
+    if (isDsheetWorkerSupported()) {
+      parsed = await runDsheetWorkerTask((api) =>
+        api.parseXlsxWorkbook(file, parseSettings),
+      );
     }
-    const file = input?.files?.[0] || fileArg;
-    /** dataVerification per sheet: sheetIndex -> { row_column: entry } */
-    const dataVerificationBySheet: Record<
-      number,
-      Record<string, Record<string, unknown>>
-    > = {};
-    /** conditional formatting per sheet: sheetIndex -> luckysheet_conditionformat_save array */
-    const conditionFormatBySheet: Record<number, Record<string, unknown>[]> =
-      {};
-    let unsupportedFilterWarningReported = false;
+  } catch (workerError) {
+    console.warn(
+      '[xlsx-import] worker parse failed; falling back to main thread',
+      workerError,
+    );
+    parsed = null;
+  }
 
-    return new Promise<void>((resolve, reject) => {
-      const reader = new FileReader();
-      reader.onerror = () => reject(new Error('Failed to read file'));
-      reader.onload = async (e) => {
-        if (!e.target) {
-          console.error('FileReader event target is null');
-          reject(new Error('FileReader event target is null'));
-          return;
-        }
-        const arrayBuffer = e.target.result;
-        const [{ Workbook }, luckyexcelMod, imageUtils] = await Promise.all([
-          import('exceljs'),
-          // @ts-expect-error — luckyexcel ships without TypeScript types
-          import('luckyexcel'),
-          import('../utils/xlsx-image-utils'),
-        ]);
-        const transformExcelToLucky =
-          luckyexcelMod.default.transformExcelToLucky;
-        const { extractImagesFromWorksheet, convertRawImagesToFortuneSheet } =
-          imageUtils;
-        const workbook = new Workbook();
-        try {
-          //@ts-expect-error, later
-          await workbook.xlsx.load(arrayBuffer);
+  try {
+    if (!parsed) {
+      parsed = await parseXlsxWorkbook(file, parseSettings);
+    }
+  } catch (error) {
+    console.error('Error loading the workbook', error);
+    if (!options?.suppressUiWarnings && typeof alert !== 'undefined') {
+      alert(
+        'Error loading the workbook. Please ensure it is a valid .xlsx file.',
+      );
+    }
+    throw error;
+  }
 
-          const workbookDefaultFontSize: number | undefined = (workbook as any)
-            .model?.styles?.fonts?.[0]?.size;
-          // Extract hyperlinks, freeze info, cell formatting, and data validation from all worksheets
-          const hyperlinksBySheet: Record<
-            number,
-            Record<string, { linkType: string; linkAddress: string }[]>
-          > = {};
-          const frozenBySheet: Record<
-            number,
-            {
-              type:
-                | 'row'
-                | 'column'
-                | 'both'
-                | 'rangeRow'
-                | 'rangeColumn'
-                | 'rangeBoth';
-              range: { row_focus: number; column_focus: number };
-            }
-          > = {};
-          const cellStylesBySheet: Record<
-            number,
-            Record<
-              string,
-              {
-                bl?: number;
-                it?: number;
-                fs?: number;
-                ff?: string;
-                fc?: string;
-                bg?: string;
-                un?: number;
-              }
-            >
-          > = {};
-          // Raw image data keyed by 0-based sheet index.
-          // Pixel positions are deferred to sheets.map where FortuneSheet
-          // column/row dimensions are available.
-          const imagesBySheet: Record<number, RawSheetImage[]> = {};
+  replayImportWarnings(
+    parsed.warnings,
+    { filterToastShown, setFilterToastShown },
+    options,
+  );
+  remapGeneratedSheetIds(parsed, sheetEditorRef, options);
 
-          workbook.eachSheet((ws, sheetIndex) => {
-            const idx = sheetIndex - 1; // exceljs is 1-based
+  const sheets = parsed.sheets;
+  console.log('[xlsx-import] parsed sheets data', {
+    fileName: file.name,
+    sheetCount: sheets.length,
+    sheets,
+  });
 
-            // Hyperlinks
-            const sheetHyperlinks: Record<
-              string,
-              { linkType: string; linkAddress: string }[]
-            > = {};
+  if (!ydocRef.current) {
+    console.error('ydocRef.current is null');
+    return;
+  }
+  const sheetArray = ydocRef.current.getArray(dsheetId);
+  const localSheetsArray = Array.from(sheetArray) as Sheet[];
 
-            // Freeze panes from worksheet views
-            const views = ws.views;
-            if (views && views.length > 0) {
-              const view = views[0];
-              if (view.state === 'frozen') {
-                const xSplit = view.xSplit || 0;
-                const ySplit = view.ySplit || 0;
-                let type: 'rangeRow' | 'rangeColumn' | 'rangeBoth' | null =
-                  null;
-                if (xSplit > 0 && ySplit > 0) type = 'rangeBoth';
-                else if (ySplit > 0) type = 'rangeRow';
-                else if (xSplit > 0) type = 'rangeColumn';
-                if (type) {
-                  frozenBySheet[idx] = {
-                    type,
-                    range: {
-                      row_focus: ySplit - 1,
-                      column_focus: xSplit - 1,
-                    },
-                  };
-                }
-              }
-            }
+  let combinedSheets;
 
-            // Cell-level formatting and hyperlinks
-            const styles: Record<
-              string,
-              {
-                bl?: number;
-                it?: number;
-                fs?: number;
-                ff?: string;
-                fc?: string;
-                bg?: string;
-                un?: number;
-              }
-            > = {};
-            ws.eachRow({ includeEmpty: false }, (row, rowNumber) => {
-              row.eachCell({ includeEmpty: false }, (cell, colNumber) => {
-                const key = `${rowNumber - 1}_${colNumber - 1}`;
-
-                if (cell.hyperlink) {
-                  sheetHyperlinks[key] = [
-                    {
-                      linkType: 'webpage',
-                      linkAddress: cell.hyperlink,
-                    },
-                  ];
-                }
-
-                // Extract cell formatting
-                const font = cell.style?.font;
-                const fill = cell.style?.fill;
-                const cellStyle: Record<string, string | number> = {};
-
-                if (font) {
-                  if (font.bold) cellStyle.bl = 1;
-                  if (font.italic) cellStyle.it = 1;
-                  if (font.underline) cellStyle.un = 1;
-                  const effectiveFontSize =
-                    font.size ?? workbookDefaultFontSize;
-                  if (effectiveFontSize) cellStyle.fs = effectiveFontSize;
-                  if (font.name) cellStyle.ff = font.name;
-                  if (font.color?.argb) {
-                    const argb = font.color.argb;
-                    const hex = '#' + argb.substring(argb.length - 6);
-                    cellStyle.fc = hex;
-                  }
-                }
-                if (
-                  fill?.type === 'pattern' &&
-                  fill.pattern === 'solid' &&
-                  fill.fgColor
-                ) {
-                  if (fill.fgColor.argb) {
-                    const argb = fill.fgColor.argb;
-                    const hex = '#' + argb.substring(argb.length - 6);
-                    cellStyle.bg = hex;
-                  }
-                }
-                if (Object.keys(cellStyle).length > 0) {
-                  styles[key] = cellStyle;
-                }
-              });
-            });
-
-            if (Object.keys(sheetHyperlinks).length > 0) {
-              hyperlinksBySheet[idx] = sheetHyperlinks;
-            }
-            if (Object.keys(styles).length > 0) {
-              cellStylesBySheet[idx] = styles;
-            }
-
-            // Extract images — pixel positions are deferred to sheets.map
-            const sheetImages = extractImagesFromWorksheet(ws, workbook);
-            if (sheetImages.length > 0) imagesBySheet[idx] = sheetImages;
-
-            // Log table data if present (for inspection purposes)
-            const wsTables = (ws as any).tables;
-            if (wsTables && Object.keys(wsTables).length > 0) {
-              options?.onWarning?.(
-                'Tables are not fully supported. Table styles will not be applied.',
-              );
-              if (!options?.suppressUiWarnings) {
-                toast({
-                  title: 'Tables are not fully supported',
-                  description: 'Table styles will not be applied',
-                  variant: 'warning',
-                  showCloseButton: true,
-                  duration: 40 * 1000,
-                });
-              }
-            }
-
-            // Extract data validation for this sheet (row_column keys for dataVerification)
-            const dvModel = (
-              ws as { dataValidations?: { model?: Record<string, unknown> } }
-            ).dataValidations?.model;
-            if (dvModel && typeof dvModel === 'object') {
-              const sheetDv: Record<string, Record<string, unknown>> = {};
-              for (const [address, dv] of Object.entries(dvModel)) {
-                const dvObj = dv as {
-                  type?: string;
-                  formulae?: unknown[];
-                  prompt?: string;
-                  showInputMessage?: boolean;
-                  allowBlank?: boolean;
-                };
-                const result = excelDataValidationToSheetEntry(address, dvObj);
-                if (result) sheetDv[result.rowColKey] = result.entry;
-              }
-              if (Object.keys(sheetDv).length > 0) {
-                dataVerificationBySheet[idx] = sheetDv;
-              }
-            }
-
-            // Extract conditional formatting for this sheet (luckysheet_conditionformat_save)
-            const cfs = (
-              ws as {
-                conditionalFormattings?: { ref: string; rules: unknown[] }[];
-              }
-            ).conditionalFormattings;
-            if (Array.isArray(cfs) && cfs.length > 0) {
-              const sheetCf: Record<string, unknown>[] = [];
-              for (const cf of cfs) {
-                const ref = cf.ref;
-                const rules = cf.rules || [];
-                for (const rule of rules) {
-                  const r = rule as {
-                    type?: string;
-                    operator?: string;
-                    formulae?: string[];
-                    style?: Record<string, unknown>;
-                    text?: string;
-                    timePeriod?: string;
-                    percent?: boolean;
-                    bottom?: boolean;
-                    rank?: number;
-                    aboveAverage?: boolean;
-                  };
-                  console.log('[XLSX CF RAW]', {
-                    ref,
-                    type: r.type,
-                    operator: r.operator,
-                    formulae: r.formulae,
-                    text: r.text,
-                    timePeriod: r.timePeriod,
-                    percent: r.percent,
-                    bottom: r.bottom,
-                    rank: r.rank,
-                    aboveAverage: r.aboveAverage,
-                  });
-                  const entry = r.type ? excelCfRuleToLuckysheet(ref, r) : null;
-                  if (!entry) {
-                    console.log('[XLSX CF MAPPED] skipped', {
-                      ref,
-                      type: r.type,
-                      operator: r.operator,
-                      formulae: r.formulae,
-                      text: r.text,
-                    });
-                  } else {
-                    console.log('[XLSX CF MAPPED] accepted', entry);
-                  }
-                  if (entry) sheetCf.push(entry);
-                }
-              }
-              if (sheetCf.length > 0) {
-                conditionFormatBySheet[idx] = sheetCf;
-              }
-            }
-
-            const autoFilter = (ws as any).autoFilter;
-            if (autoFilter) {
-              if (!unsupportedFilterWarningReported) {
-                unsupportedFilterWarningReported = true;
-                options?.onWarning?.(
-                  'Filters are not supported in imported files.',
-                );
-              }
-              if (!filterToastShown) {
-                setFilterToastShown(true);
-                if (!options?.suppressUiWarnings) {
-                  toast({
-                    title: 'Filters are not supported in imported files',
-                    variant: 'warning',
-                    showCloseButton: true,
-                    duration: 30 * 1000,
-                  });
-                }
-              }
-            }
-          }); // close workbook.eachSheet
-
-          transformExcelToLucky(
-            file,
-            function (exportJson: { sheets: Sheet[] }) {
-              let sheets = exportJson.sheets;
-              sheets.forEach((sheet, sheetIndex) => {
-                const sheetDv = dataVerificationBySheet[sheetIndex];
-                if (sheetDv && Object.keys(sheetDv).length > 0) {
-                  sheet.dataVerification = sheetDv;
-                }
-                // Always set condition format: use our imported rules or empty array. Avoids leaving
-                // stale/malformed rules from luckyexcel (e.g. type "colorGradation" with undefined format)
-                // which cause "Cannot read properties of undefined (reading '0')" in fortune-core ConditionFormat.js
-                const sheetCf = conditionFormatBySheet[sheetIndex];
-                sheet.luckysheet_conditionformat_save =
-                  Array.isArray(sheetCf) && sheetCf.length > 0 ? sheetCf : [];
-              });
-
-              if (!ydocRef.current) {
-                console.error('ydocRef.current is null');
-                return;
-              }
-              const sheetArray = ydocRef.current.getArray(dsheetId);
-              const localSheetsArray = Array.from(sheetArray) as Sheet[];
-              const isDateCache = new Map<string, boolean>();
-              sheets = sheets.map((sheet, sheetIndex) => {
-                const lastCell = sheet?.celldata?.[sheet.celldata.length - 1];
-
-                const lastRow = lastCell?.r ?? 0;
-                const lastCol = lastCell?.c ?? 0;
-
-                sheet.row = Math.max(lastRow, 500);
-                sheet.column = Math.max(lastCol, 36);
-
-                if (!sheet.id) {
-                  sheet.id =
-                    options?.generateSheetId?.() ??
-                    sheetEditorRef.current?.getSettings().generateSheetId() ??
-                    generateImportSheetId();
-                }
-                // Attach freeze pane info
-                if (frozenBySheet[sheetIndex]) {
-                  sheet.frozen = frozenBySheet[sheetIndex];
-                }
-                // Attach hyperlinks extracted from exceljs for this sheet
-                if (hyperlinksBySheet[sheetIndex]) {
-                  sheet.hyperlink = {
-                    ...(sheet.hyperlink || {}),
-                    ...hyperlinksBySheet[sheetIndex],
-                  };
-                }
-                // Correct column widths before image position conversion so that
-                // nativeColToPx uses the same MDW=7 values the grid renders with.
-                if (sheet.config?.columnlen) {
-                  const corrected: Record<string, number> = {};
-                  Object.entries(sheet.config.columnlen).forEach(
-                    ([col, px]) => {
-                      const wch = (Number(px) - 5) / 8 + 0.83;
-                      corrected[col] = Math.round(wch * 7 + 5);
-                    },
-                  );
-                  sheet.config.columnlen = corrected;
-                }
-
-                const defaultColPx = Math.round(
-                  Number(sheet.defaultColWidth) || 73,
-                );
-                if (sheet.config?.columnlen) {
-                  const filteredCols: Record<string, number> = {};
-                  Object.entries(sheet.config.columnlen).forEach(([col, w]) => {
-                    if (Math.abs(Math.round(Number(w)) - defaultColPx) > 1) {
-                      filteredCols[col] = Number(w);
-                    }
-                  });
-                  sheet.config.columnlen = filteredCols;
-                }
-
-                // Drop rowlen entries at or near the default row height so Fortune
-                // uses its own default for rows the user never manually resized.
-                // Also done before image conversion so nativeRowToPx uses the
-                // same rowlen the grid renders with.
-                if (sheet.config?.rowlen) {
-                  const defaultRowPx = Math.round(
-                    Number(sheet.defaultRowHeight) || 21,
-                  );
-                  const filtered: Record<string, number> = {};
-                  Object.entries(sheet.config.rowlen).forEach(([row, h]) => {
-                    if (Math.abs(Math.round(Number(h)) - defaultRowPx) > 1) {
-                      filtered[row] = Number(h);
-                    }
-                  });
-                  sheet.config.rowlen = filtered;
-                }
-
-                if (sheet.config?.customHeight) {
-                  const keep = new Set<string>(
-                    Object.keys((sheet.config.rowlen as any) || {}),
-                  );
-                  const next: Record<string, number> = {};
-                  Object.entries(sheet.config.customHeight).forEach(
-                    ([row, flag]) => {
-                      if (keep.has(row) && Number(flag) === 1) {
-                        next[row] = 1;
-                      }
-                    },
-                  );
-                  sheet.config.customHeight = next;
-                }
-
-                // Attach images — convert fractional col/row to pixels using
-                // FortuneSheet's actual column/row dimensions so positions match.
-                if (imagesBySheet[sheetIndex]) {
-                  const defaultColPx =
-                    Number(sheet.defaultColWidth) ||
-                    Number(
-                      sheetEditorRef.current?.getSettings?.()?.defaultColWidth,
-                    ) ||
-                    99;
-                  const defaultRowPx =
-                    Number(sheet.defaultRowHeight) ||
-                    Number(
-                      sheetEditorRef.current?.getSettings?.()?.defaultRowHeight,
-                    ) ||
-                    21;
-                  sheet.images = convertRawImagesToFortuneSheet(
-                    imagesBySheet[sheetIndex],
-                    sheet,
-                    defaultColPx,
-                    defaultRowPx,
-                  );
-                }
-                // Apply cell formatting from exceljs (hyperlink styling, bold, italic, bg, etc.)
-                // Also fix date cells: set ct.t="d", coerce v to number, compute m
-                const hlKeys = hyperlinksBySheet[sheetIndex];
-                const styleKeys = cellStylesBySheet[sheetIndex];
-                const calcChain: { r: number; c: number; id: string }[] = [];
-                const pushCalcChainOnce = (r: number, c: number) => {
-                  const k = `${r}_${c}`;
-                  if ((pushCalcChainOnce as any)._seen == null) {
-                    (pushCalcChainOnce as any)._seen = new Set<string>();
-                  }
-                  const seen = (pushCalcChainOnce as any)._seen as Set<string>;
-                  if (seen.has(k)) return;
-                  seen.add(k);
-                  calcChain.push({ r, c, id: sheet.id as string });
-                };
-                // Built during the celldata loop below; only allocated when merges exist
-                const celldataMap = sheet.config?.merge
-                  ? new Map<
-                      string,
-                      { r: number; c: number; v: Record<string, unknown> }
-                    >()
-                  : null;
-                if (sheet.celldata) {
-                  for (const cell of sheet.celldata) {
-                    const key = `${cell.r}_${cell.c}`;
-                    celldataMap?.set(
-                      key,
-                      cell as {
-                        r: number;
-                        c: number;
-                        v: Record<string, unknown>;
-                      },
-                    );
-                    if (cell.v) {
-                      if (cell.v.f) {
-                        const fStr = String(cell.v.f);
-                        if (!fStr.startsWith('=')) {
-                          cell.v.f = `=${fStr}`;
-                        }
-                      }
-                      // Mark formula cells so FortuneSheet recalculates them on dependency change.
-                      // Keep cached m/v so the workbook shows something during the remount phase;
-                      // schedulePostImportFormulaRecalc will overwrite them once the engine runs.
-                      if (cell.v.f && cell.v.ct?.t !== 'd') {
-                        cell.v.ct = { ...(cell.v.ct ?? {}), t: 'str' };
-                        pushCalcChainOnce(cell.r, cell.c);
-                      }
-                      // Apply formatting extracted from exceljs
-                      if (styleKeys?.[key]) {
-                        const styleFromExcel = styleKeys[key] as Record<
-                          string,
-                          unknown
-                        >;
-                        const hasHyperlink = !!hlKeys?.[key];
-                        if (hasHyperlink) {
-                          // Hyperlink cells: avoid root-level fc/un inheritance.
-                          const { fc: _fc, un: _un, ...rest } = styleFromExcel;
-                          void _fc;
-                          void _un;
-                          Object.assign(cell.v, rest);
-                        } else {
-                          Object.assign(cell.v, styleFromExcel);
-                        }
-                      }
-                      // Hyperlink cells: shared normalization (single ct.s run, styles on segment only).
-                      if (hlKeys?.[key] && !cell.v.f) {
-                        const hyperlink = hlKeys[key][0];
-                        if (hyperlink) {
-                          normalizeImportedHyperlinkCellV(
-                            cell.v as Record<string, unknown>,
-                            hyperlink,
-                          );
-                        }
-                      }
-                      // Fix date cells: luckyexcel leaves ct.t unset and v as a string
-                      const fa = cell.v.ct?.fa;
-                      const normalizedFa =
-                        typeof fa === 'string' ? fa.trim().toLowerCase() : '';
-                      const isGeneralLikeFormat =
-                        normalizedFa === 'general' || cell.v.ct?.t === 'g';
-                      const isTextLikeFormat =
-                        normalizedFa === '@' || cell.v.ct?.t === 's';
-                      if (fa && !isDateCache.has(fa)) {
-                        isDateCache.set(fa, SSF.is_date(fa));
-                      }
-
-                      if (!cell.v.f && fa && isDateCache.get(fa)) {
-                        const numV =
-                          typeof cell.v.v === 'string'
-                            ? parseFloat(cell.v.v)
-                            : cell.v.v;
-                        if (typeof numV === 'number' && !isNaN(numV)) {
-                          try {
-                            cell.v.v = numV;
-                            cell.v.m = SSF.format(fa, numV);
-                            cell.v.ct = { ...cell.v.ct, t: 'd' };
-                          } catch {
-                            // malformed format string — leave cell as-is
-                          }
-                        }
-                        // luckyexcel stores numeric values as strings (e.g. "59.0"); parse to number and recompute m so integers don't display with a trailing ".0"
-                      } else if (
-                        !cell.v.f &&
-                        typeof cell.v.v === 'string' &&
-                        !isTextLikeFormat &&
-                        !isGeneralLikeFormat
-                      ) {
-                        const rawStringValue = (cell.v.v as string).trim();
-                        const isStrictNumericString =
-                          /^[-+]?(?:\d+\.?\d*|\.\d+)(?:[eE][-+]?\d+)?$/.test(
-                            rawStringValue,
-                          );
-                        if (isStrictNumericString) {
-                          const numV = Number(rawStringValue);
-                          if (!isFinite(numV)) {
-                            continue;
-                          }
-                          cell.v.v = numV;
-                          if (cell.v.ht == null) {
-                            cell.v.ht = 2;
-                          }
-                          if (!fa) {
-                            cell.v.m = String(numV);
-                          } else {
-                            try {
-                              cell.v.m = SSF.format(fa, numV);
-                            } catch {
-                              // malformed format string — leave m as-is
-                            }
-                          }
-                        }
-                      } else if (
-                        !cell.v.f &&
-                        typeof cell.v.v === 'number' &&
-                        isFinite(cell.v.v) &&
-                        cell.v.ct?.t !== 's' &&
-                        cell.v.ct?.t !== 'd'
-                      ) {
-                        if (cell.v.ht == null) {
-                          cell.v.ht = 2;
-                        }
-                      }
-
-                      // Ensure non-empty imported cells always have a display mask `m`.
-                      // Filter-by-values uses `m` for display; when it is missing, values collapse to (Null).
-                      if (
-                        !cell.v.f &&
-                        (cell.v.m === undefined || cell.v.m === null) &&
-                        cell.v.ct?.t !== 'd'
-                      ) {
-                        const richText = richTextRunsToPlainText(cell.v.ct?.s);
-                        const rawV = cell.v.v;
-                        const isBlankLike =
-                          rawV == null || String(rawV).trim() === '';
-                        if (!isBlankLike) {
-                          // Prefer rich text if present (hyperlinks are typically stored in ct.s).
-                          if (richText != null) {
-                            cell.v.m = richText;
-                          } else if (typeof rawV === 'boolean') {
-                            cell.v.m = excelishBooleanText(rawV);
-                          } else if (
-                            typeof rawV === 'number' &&
-                            isFinite(rawV)
-                          ) {
-                            const fa2 = cell.v.ct?.fa;
-                            if (
-                              typeof fa2 === 'string' &&
-                              fa2 &&
-                              isDateCache.get(fa2) === false
-                            ) {
-                              try {
-                                cell.v.m = SSF.format(fa2, rawV);
-                              } catch {
-                                cell.v.m = String(rawV);
-                              }
-                            } else {
-                              cell.v.m = String(rawV);
-                            }
-                          } else if (typeof rawV === 'object') {
-                            // Unknown complex value; leave `m` unset to avoid misleading text.
-                          } else {
-                            cell.v.m = String(rawV);
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-
-                // Normalize formula cells in the data grid (luckyexcel may populate sheet.data
-                // in addition to sheet.celldata). Keep cached m/v for display during remount.
-                if (Array.isArray((sheet as any).data)) {
-                  const data = (sheet as any).data as any[][];
-                  for (let r = 0; r < data.length; r++) {
-                    const row = data[r];
-                    if (!Array.isArray(row)) continue;
-                    for (let c = 0; c < row.length; c++) {
-                      const v = row[c];
-                      if (!v || typeof v !== 'object') continue;
-                      if (!v.f) continue;
-
-                      const fStr = String(v.f);
-                      if (!fStr.startsWith('=')) v.f = `=${fStr}`;
-                      if (v.ct?.t !== 'd') {
-                        v.ct = { ...(v.ct ?? {}), t: 'str' };
-                        pushCalcChainOnce(r, c);
-                      }
-                    }
-                  }
-                }
-
-                sheet.calcChain = calcChain;
-
-                // luckyexcel only sets config.merge but not cell-level mc properties.
-                // FortuneSheet's canvas renderer needs mc on each cell in the merge range.
-                // celldataMap was built during the celldata loop above (single pass).
-                if (celldataMap && sheet.config?.merge && sheet.celldata) {
-                  for (const merge of Object.values(sheet.config.merge) as {
-                    r: number;
-                    c: number;
-                    rs: number;
-                    cs: number;
-                  }[]) {
-                    const { r, c, rs, cs } = merge;
-                    for (let dr = 0; dr < rs; dr++) {
-                      for (let dc = 0; dc < cs; dc++) {
-                        const key = `${r + dr}_${c + dc}`;
-                        const isAnchor = dr === 0 && dc === 0;
-                        let cell = celldataMap.get(key);
-                        if (!cell) {
-                          cell = {
-                            r: r + dr,
-                            c: c + dc,
-                            v: isAnchor
-                              ? { mc: { r, c, rs, cs } }
-                              : { mc: { r, c } },
-                          };
-                          sheet.celldata.push(cell as never);
-                          celldataMap.set(key, cell);
-                        } else {
-                          if (!cell.v) cell.v = {};
-                          cell.v.mc = isAnchor
-                            ? { r, c, rs, cs }
-                            : { r, c };
-                        }
-                      }
-                    }
-                  }
-                }
-
-                internImportedDataVerification(sheet);
-                compactImportedSheetFormatting(sheet);
-
-                return sheet;
-              });
-              console.log('[xlsx-import] parsed sheets data', {
-                fileName: file.name,
-                sheetCount: sheets.length,
-                sheets,
-              });
-
-              let combinedSheets;
-
-              if (importType === 'merge-current-dsheet') {
-                const usedNames = new Set<string>(
-                  localSheetsArray
-                    .map((s) =>
-                      s instanceof Y.Map ? s.get('name') : (s as Sheet).name,
-                    )
-                    .filter(Boolean) as string[],
-                );
-                sheets.forEach((sheet) => {
-                  const original = sheet.name ?? '';
-                  const uniqueName = makeUniqueSheetName(original, usedNames);
-                  if (uniqueName !== original) {
-                    sheet.name = uniqueName;
-                  }
-                  usedNames.add(uniqueName);
-                });
-                combinedSheets = [...localSheetsArray, ...sheets];
-              } else {
-                combinedSheets = [...sheets];
-              }
-
-              combinedSheets = combinedSheets.map((sheet, index) => {
-                sheet.order = index;
-                return sheet;
-              });
-
-              const ydoc = ydocRef.current;
-              ydoc.transact(() => {
-                if (importType !== 'merge-current-dsheet') {
-                  sheetArray.delete(0, sheetArray.length);
-                }
-
-                combinedSheets.forEach((sheet) => {
-                  if (sheet instanceof Y.Map) return;
-
-                  const factory = migrateSheetFactoryForImport(sheet);
-                  sheetArray.push([factory()]);
-                });
-              });
-
-              // Update UI immediately so sync handler sees correct count before it can run
-              if (ydocRef?.current) {
-                const arr = ydocRef.current.getArray(dsheetId);
-                const plain = ySheetArrayToPlain(arr);
-                currentDataRef.current = plain;
-                setForceSheetRender((prev: number) => prev + 1);
-              }
-              // Mirror CSV import: persist Yjs body to host Dexie (share/publish read IDB content).
-              setTimeout(() => {
-                handleContentPortal?.();
-              }, 200);
-              if (!options?.headless) {
-                schedulePostImportFormulaRecalc(sheetEditorRef);
-              }
-              // @ts-expect-error later
-              const fileName = removeFileExtension(exportJson?.info?.name);
-              updateDocumentTitle?.(fileName);
-              resolve();
-            },
-          );
-        } catch (error) {
-          console.error('Error loading the workbook', error);
-          if (!options?.suppressUiWarnings && typeof alert !== 'undefined') {
-            alert(
-              'Error loading the workbook. Please ensure it is a valid .xlsx file.',
-            );
-          }
-          reject(error);
-        }
-      };
-
-      reader.readAsArrayBuffer(file);
+  if (importType === 'merge-current-dsheet') {
+    const usedNames = new Set<string>(
+      localSheetsArray
+        .map((s) => (s instanceof Y.Map ? s.get('name') : (s as Sheet).name))
+        .filter(Boolean) as string[],
+    );
+    sheets.forEach((sheet) => {
+      const original = sheet.name ?? '';
+      const uniqueName = makeUniqueSheetName(original, usedNames);
+      if (uniqueName !== original) {
+        sheet.name = uniqueName;
+      }
+      usedNames.add(uniqueName);
     });
+    combinedSheets = [...localSheetsArray, ...sheets];
+  } else {
+    combinedSheets = [...sheets];
+  }
+
+  combinedSheets = combinedSheets.map((sheet, index) => {
+    sheet.order = index;
+    return sheet;
+  });
+
+  const ydoc = ydocRef.current;
+  ydoc.transact(() => {
+    if (importType !== 'merge-current-dsheet') {
+      sheetArray.delete(0, sheetArray.length);
+    }
+
+    combinedSheets.forEach((sheet) => {
+      if (sheet instanceof Y.Map) return;
+
+      const factory = migrateSheetFactoryForImport(sheet);
+      sheetArray.push([factory()]);
+    });
+  });
+
+  // Update UI immediately so sync handler sees correct count before it can run
+  if (ydocRef?.current) {
+    const arr = ydocRef.current.getArray(dsheetId);
+    const plain = ySheetArrayToPlain(arr);
+    currentDataRef.current = plain;
+    setForceSheetRender((prev: number) => prev + 1);
+  }
+  // Mirror CSV import: persist Yjs body to host Dexie (share/publish read IDB content).
+  setTimeout(() => {
+    handleContentPortal?.();
+  }, 200);
+  if (!options?.headless) {
+    schedulePostImportFormulaRecalc(sheetEditorRef);
+  }
+  const fileName = removeFileExtension(parsed.workbookName);
+  updateDocumentTitle?.(fileName);
 }

--- a/src/editor/hooks/use-xlsx-import-impl.tsx
+++ b/src/editor/hooks/use-xlsx-import-impl.tsx
@@ -4,6 +4,10 @@ import SSF from 'ssf';
 import * as Y from 'yjs';
 import { Sheet, WorkbookInstance } from '@sheet-engine/react';
 import { migrateSheetFactoryForImport } from '../utils/migrate-new-yjs';
+import {
+  compactImportedSheetFormatting,
+  internImportedDataVerification,
+} from '../utils/import-compaction';
 import { ySheetArrayToPlain } from '../utils/update-ydoc';
 
 import type { RawSheetImage } from '../utils/xlsx-image-utils';
@@ -1349,6 +1353,9 @@ export async function runXlsxFileUpload(
                     }
                   }
                 }
+
+                internImportedDataVerification(sheet);
+                compactImportedSheetFormatting(sheet);
 
                 return sheet;
               });

--- a/src/editor/utils/compact-committed-celldata.ts
+++ b/src/editor/utils/compact-committed-celldata.ts
@@ -45,21 +45,23 @@ export function getAnchorSheet(sheets: Sheet[] | null | undefined): Sheet | null
 function getAnchorSheetEntry(
   sheetArray: Y.Array<unknown>,
 ): { sheetId: string; entry: Y.Map<unknown> } | null {
-  let anchor: { sheetId: string; entry: Y.Map<unknown>; order: number } | null =
+  let best: { sheetId: string; entry: Y.Map<unknown>; order: number } | null =
     null;
 
-  sheetArray.forEach((sheetEntry) => {
-    if (!(sheetEntry instanceof Y.Map)) return;
+  for (let i = 0; i < sheetArray.length; i += 1) {
+    const sheetEntry = sheetArray.get(i);
+    if (!(sheetEntry instanceof Y.Map)) continue;
     const sheetId = sheetEntry.get('id');
-    if (typeof sheetId !== 'string') return;
+    if (typeof sheetId !== 'string') continue;
     const order = sheetEntry.get('order');
     const orderNum = typeof order === 'number' ? order : 0;
-    if (!anchor || orderNum < anchor.order) {
-      anchor = { sheetId, entry: sheetEntry, order: orderNum };
+    if (!best || orderNum < best.order) {
+      best = { sheetId, entry: sheetEntry, order: orderNum };
     }
-  });
+  }
 
-  return anchor ? { sheetId: anchor.sheetId, entry: anchor.entry } : null;
+  if (!best) return null;
+  return { sheetId: best.sheetId, entry: best.entry };
 }
 
 export function hasSheetCompactionCompleted(

--- a/src/editor/utils/compact-committed-celldata.ts
+++ b/src/editor/utils/compact-committed-celldata.ts
@@ -1,36 +1,106 @@
 import * as Y from 'yjs';
 import type { CellMatrix, CellWithRowAndCol, Sheet } from '../../sheet-engine/core/types';
+import { compactBorderInfo } from '../../sheet-engine/core/paste/paste-border-utils';
 import { shouldPersistCelldataCell } from '../../sheet-engine/core/utils/cell-persist-utils';
 import type { SheetChangePath } from './update-ydoc';
 
-export const CELLDATA_COMPACT_STORAGE_KEY_PREFIX = 'dsheet-celldata-compact-v1:';
+/** Celldata + borderInfo compaction; bump when rules change. */
+export const SHEET_COMPACTION_REV = 2;
+export const SHEET_COMPACTION_CONFIG_KEY = 'sheetCompactionRev';
 
-export type CelldataCompactionResult = {
+export type SheetCompactionResult = {
   removedFromYdoc: number;
   clearedInMemory: number;
   changes: SheetChangePath[];
 };
 
-export function celldataCompactStorageKey(dsheetId: string): string {
-  return `${CELLDATA_COMPACT_STORAGE_KEY_PREFIX}${dsheetId}`;
+function readConfigValue(config: unknown, key: string): unknown {
+  if (config instanceof Y.Map) return config.get(key);
+  if (config && typeof config === 'object') {
+    return (config as Record<string, unknown>)[key];
+  }
+  return undefined;
 }
 
-export function hasCelldataCompactionCompleted(dsheetId: string): boolean {
-  if (typeof window === 'undefined' || !dsheetId) return true;
-  try {
-    return window.localStorage.getItem(celldataCompactStorageKey(dsheetId)) === '1';
-  } catch {
-    return true;
-  }
+function readConfigBorderInfo(config: unknown): any[] | null {
+  const value = readConfigValue(config, 'borderInfo');
+  return Array.isArray(value) ? value : null;
 }
 
-export function markCelldataCompactionCompleted(dsheetId: string): void {
-  if (typeof window === 'undefined' || !dsheetId) return;
-  try {
-    window.localStorage.setItem(celldataCompactStorageKey(dsheetId), '1');
-  } catch {
-    // ignore quota / privacy mode
+export function readSheetCompactionRev(config: unknown): number {
+  const value = readConfigValue(config, SHEET_COMPACTION_CONFIG_KEY);
+  return typeof value === 'number' ? value : 0;
+}
+
+export function getAnchorSheet(sheets: Sheet[] | null | undefined): Sheet | null {
+  if (!sheets?.length) return null;
+  let anchor = sheets[0];
+  for (let i = 1; i < sheets.length; i += 1) {
+    const sheet = sheets[i];
+    if ((sheet.order ?? 0) < (anchor.order ?? 0)) anchor = sheet;
   }
+  return anchor;
+}
+
+function getAnchorSheetEntry(
+  sheetArray: Y.Array<unknown>,
+): { sheetId: string; entry: Y.Map<unknown> } | null {
+  let anchor: { sheetId: string; entry: Y.Map<unknown>; order: number } | null =
+    null;
+
+  sheetArray.forEach((sheetEntry) => {
+    if (!(sheetEntry instanceof Y.Map)) return;
+    const sheetId = sheetEntry.get('id');
+    if (typeof sheetId !== 'string') return;
+    const order = sheetEntry.get('order');
+    const orderNum = typeof order === 'number' ? order : 0;
+    if (!anchor || orderNum < anchor.order) {
+      anchor = { sheetId, entry: sheetEntry, order: orderNum };
+    }
+  });
+
+  return anchor ? { sheetId: anchor.sheetId, entry: anchor.entry } : null;
+}
+
+export function hasSheetCompactionCompleted(
+  ydoc: Y.Doc,
+  dsheetId: string,
+): boolean {
+  const anchor = getAnchorSheetEntry(ydoc.getArray(dsheetId));
+  if (!anchor) return true;
+  return (
+    readSheetCompactionRev(anchor.entry.get('config')) >= SHEET_COMPACTION_REV
+  );
+}
+
+export function buildCompactionRevChange(
+  ydoc: Y.Doc,
+  dsheetId: string,
+): SheetChangePath | null {
+  const anchor = getAnchorSheetEntry(ydoc.getArray(dsheetId));
+  if (!anchor) return null;
+  if (
+    readSheetCompactionRev(anchor.entry.get('config')) >= SHEET_COMPACTION_REV
+  ) {
+    return null;
+  }
+  return {
+    sheetId: anchor.sheetId,
+    path: ['config', SHEET_COMPACTION_CONFIG_KEY],
+    value: SHEET_COMPACTION_REV,
+    type: 'update',
+  };
+}
+
+export function markCompactionRevInMemory(
+  sheets: Sheet[] | null | undefined,
+): void {
+  const anchor = getAnchorSheet(sheets);
+  if (!anchor) return;
+  anchor.config = {
+    ...(anchor.config ?? {}),
+    [SHEET_COMPACTION_CONFIG_KEY]: SHEET_COMPACTION_REV,
+  };
 }
 
 function cellFromCelldataEntry(entry: unknown): unknown {
@@ -77,7 +147,6 @@ export function buildCelldataDeleteChanges(
     key,
     value: null,
     type: 'delete' as const,
-    // Re-check live entry at apply time — plan may be seconds old across idle chunks.
     skipIfPersistable: true,
   }));
 }
@@ -138,18 +207,22 @@ export function compactInMemorySheets(
       sheet.celldata = next;
       cleared += removed;
     }
+    if (sheet.config?.borderInfo) {
+      const next = compactBorderInfo(sheet.config.borderInfo);
+      if (next) {
+        cleared += sheet.config.borderInfo.length - next.length;
+        sheet.config.borderInfo = next;
+      }
+    }
   }
   return cleared;
 }
 
-/**
- * Scan Y.Doc for committed celldata ghosts. Does not mutate — caller applies
- * `changes` via `updateYdocSheetData`.
- */
-export function planYdocCelldataCompaction(
+/** Scan Y.Doc for committed ghosts. Does not mutate — caller applies `changes`. */
+export function planYdocCompaction(
   ydoc: Y.Doc,
   dsheetId: string,
-): CelldataCompactionResult {
+): SheetCompactionResult {
   const changes: SheetChangePath[] = [];
   let removedFromYdoc = 0;
 
@@ -163,10 +236,22 @@ export function planYdocCelldataCompaction(
     const staleKeys = collectStaleCelldataKeys(
       celldataMap instanceof Y.Map ? celldataMap : null,
     );
-    if (staleKeys.length === 0) return;
+    if (staleKeys.length > 0) {
+      removedFromYdoc += staleKeys.length;
+      changes.push(...buildCelldataDeleteChanges(sheetId, staleKeys));
+    }
 
-    removedFromYdoc += staleKeys.length;
-    changes.push(...buildCelldataDeleteChanges(sheetId, staleKeys));
+    const borderInfo = readConfigBorderInfo(sheetEntry.get('config'));
+    const nextBorderInfo = compactBorderInfo(borderInfo ?? undefined);
+    if (nextBorderInfo) {
+      removedFromYdoc += (borderInfo?.length ?? 0) - nextBorderInfo.length;
+      changes.push({
+        sheetId,
+        path: ['config', 'borderInfo'],
+        value: nextBorderInfo,
+        type: 'update',
+      });
+    }
   });
 
   return { removedFromYdoc, clearedInMemory: 0, changes };

--- a/src/editor/utils/import-compaction.ts
+++ b/src/editor/utils/import-compaction.ts
@@ -1,0 +1,168 @@
+import { Sheet } from '@sheet-engine/react';
+import { extractCellFormatAttrs } from '../../sheet-engine/core/utils/cell-persist-utils';
+import {
+  normalizeCellFormatRanges,
+  type CellFormatRange,
+} from '../../sheet-engine/core/utils/range-format';
+
+type CelldataEntry = { r: number; c: number; v: unknown };
+
+/**
+ * XLSX imports (Google Sheets exports especially) materialize every
+ * styled-but-empty cell. Move those into config.cellFormatRanges — the same
+ * sparse representation the editor uses — so they never inflate celldata/Yjs.
+ * Cells with content, merges, hyperlinks, notes or masks are kept verbatim.
+ */
+export function compactImportedSheetFormatting(sheet: Sheet): void {
+  const celldata = sheet.celldata as CelldataEntry[] | undefined;
+  if (!Array.isArray(celldata) || celldata.length === 0) return;
+
+  const kept: CelldataEntry[] = [];
+  const stripsByAttrs = new Map<string, Map<number, number[]>>();
+  let formatOnlyCount = 0;
+
+  for (const entry of celldata) {
+    if (
+      !entry ||
+      typeof entry.r !== 'number' ||
+      typeof entry.c !== 'number'
+    ) {
+      kept.push(entry);
+      continue;
+    }
+    const attrs = extractCellFormatAttrs(
+      entry.v as Parameters<typeof extractCellFormatAttrs>[0],
+    );
+    if (!attrs) {
+      kept.push(entry);
+      continue;
+    }
+    formatOnlyCount += 1;
+    const attrsKey = JSON.stringify(attrs);
+    let byColumn = stripsByAttrs.get(attrsKey);
+    if (!byColumn) {
+      byColumn = new Map();
+      stripsByAttrs.set(attrsKey, byColumn);
+    }
+    let rows = byColumn.get(entry.c);
+    if (!rows) {
+      rows = [];
+      byColumn.set(entry.c, rows);
+    }
+    rows.push(entry.r);
+  }
+
+  if (formatOnlyCount === 0) return;
+
+  const strips: CellFormatRange[] = [];
+  stripsByAttrs.forEach((byColumn, attrsKey) => {
+    const attrs = JSON.parse(attrsKey) as Partial<CellFormatRange>;
+    byColumn.forEach((rows, column) => {
+      rows.sort((a, b) => a - b);
+      let start = rows[0];
+      let previous = rows[0];
+      for (let i = 1; i <= rows.length; i += 1) {
+        const row = rows[i];
+        if (row === previous || row === previous + 1) {
+          previous = row;
+          continue;
+        }
+        strips.push({
+          ...attrs,
+          row: [start, previous],
+          column: [column, column],
+        });
+        if (row == null) break;
+        start = row;
+        previous = row;
+      }
+    });
+  });
+
+  const existing = sheet.config?.cellFormatRanges as
+    | CellFormatRange[]
+    | undefined;
+  const ranges = normalizeCellFormatRanges([...(existing ?? []), ...strips]);
+
+  sheet.config = { ...(sheet.config ?? {}), cellFormatRanges: ranges };
+  sheet.celldata = kept as Sheet['celldata'];
+}
+
+const stableDefKey = (entry: Record<string, unknown>): string => {
+  const keys = Object.keys(entry)
+    .filter((key) => key !== 'rangeTxt')
+    .sort();
+  return JSON.stringify(keys.map((key) => [key, entry[key]]));
+};
+
+/**
+ * Imported validations repeat the full option list + per-option color string
+ * on every covered cell (whole-column dropdowns → thousands of copies). Store
+ * each unique entry once in dataVerificationDefs and keep numeric refs in the
+ * per-cell map; expandSheetDataVerification restores objects for the engine.
+ */
+export function internImportedDataVerification(sheet: Sheet): void {
+  const dv = sheet.dataVerification as
+    | Record<string, Record<string, unknown>>
+    | undefined;
+  if (!dv || typeof dv !== 'object') return;
+  const entries = Object.entries(dv);
+  if (entries.length === 0) return;
+
+  const defs: Record<string, unknown>[] = [];
+  const defIndexByKey = new Map<string, number>();
+  const interned: Record<string, unknown> = {};
+
+  for (const [cellKey, entry] of entries) {
+    if (!entry || typeof entry !== 'object') {
+      interned[cellKey] = entry;
+      continue;
+    }
+    const defKey = stableDefKey(entry);
+    let index = defIndexByKey.get(defKey);
+    if (index == null) {
+      index = defs.length;
+      defs.push(entry);
+      defIndexByKey.set(defKey, index);
+    }
+    interned[cellKey] = index;
+  }
+
+  if (defs.length >= entries.length) return;
+
+  sheet.dataVerification = interned;
+  (sheet as Sheet & { dataVerificationDefs?: unknown[] }).dataVerificationDefs =
+    defs;
+}
+
+/**
+ * Resolve interned dataVerification refs back to shared entry objects before
+ * the sheet reaches the engine or the XLSX exporter. No-op (and no mutation)
+ * when the map already holds objects, so live workbook sheets pass through.
+ */
+export function expandSheetDataVerification<
+  T extends {
+    dataVerification?: unknown;
+    dataVerificationDefs?: unknown;
+  },
+>(sheet: T): T {
+  const defs = sheet.dataVerificationDefs;
+  const dv = sheet.dataVerification;
+  if (!Array.isArray(defs) || defs.length === 0) return sheet;
+  if (!dv || typeof dv !== 'object' || Array.isArray(dv)) return sheet;
+
+  const entries = Object.entries(dv as Record<string, unknown>);
+  if (!entries.some(([, value]) => typeof value === 'number')) return sheet;
+
+  const expanded: Record<string, unknown> = {};
+  for (const [cellKey, value] of entries) {
+    if (typeof value === 'number') {
+      const def = defs[value];
+      if (def != null) expanded[cellKey] = def;
+      continue;
+    }
+    expanded[cellKey] = value;
+  }
+  sheet.dataVerification = expanded;
+  return sheet;
+}

--- a/src/editor/utils/update-ydoc.ts
+++ b/src/editor/utils/update-ydoc.ts
@@ -13,6 +13,7 @@ import {
   rangesEqual as cellFormatRangesEqual,
   type CellFormatRange,
 } from "../../sheet-engine/core/utils/range-format";
+import { expandSheetDataVerification } from "./import-compaction";
 
 export type SheetChangePath = {
   sheetId: string;
@@ -700,6 +701,7 @@ export function ySheetArrayToPlain(
     let calcChainArray;
     calcChainArray = obj.calcChain ? Object.values(obj.calcChain) : [];
     obj.calcChain = calcChainArray;
+    expandSheetDataVerification(obj);
     return obj as Sheet;
   });
 }

--- a/src/editor/utils/xlsx-export-impl.tsx
+++ b/src/editor/utils/xlsx-export-impl.tsx
@@ -15,6 +15,7 @@ import {
   type CellRichTextValue,
 } from './xlsx-richtext-utils';
 import { buildSheetDataMatrixForExport } from '../../sheet-engine/core/utils/range-format';
+import { expandSheetDataVerification } from './import-compaction';
 import {
   concatInlineStrRunsText,
   getFirstHyperlinkEntry,
@@ -105,6 +106,9 @@ export const handleExportToXLSX = async (
     ydoc.getArray(dsheetId);
 
     const sheetWithData = workbookRef.current.getAllSheets();
+    // Headless exports (folder list) pass raw ydoc sheets that may hold
+    // interned dataVerification refs; live workbook sheets pass through.
+    sheetWithData.forEach((sheet) => expandSheetDataVerification(sheet));
     const workbook = XLSXUtil.book_new();
     const sheetRichTextMaps: Map<string, CellRichTextValue>[] =
       sheetWithData.map(() => new Map());

--- a/src/editor/utils/xlsx-import-pipeline.ts
+++ b/src/editor/utils/xlsx-import-pipeline.ts
@@ -1,11 +1,18 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import SSF from 'ssf';
+import { Workbook } from 'exceljs';
+// @ts-expect-error — luckyexcel ships without TypeScript types
+import LuckyExcel from 'luckyexcel';
 import type { Sheet } from '@sheet-engine/react';
 import {
   compactImportedSheetFormatting,
   internImportedDataVerification,
 } from './import-compaction';
-import type { RawSheetImage } from './xlsx-image-utils';
+import {
+  convertRawImagesToFortuneSheet,
+  extractImagesFromWorksheet,
+  type RawSheetImage,
+} from './xlsx-image-utils';
 import { normalizeImportedHyperlinkCellV } from './xlsx-hyperlink-inline';
 
 /**
@@ -602,15 +609,7 @@ export async function parseXlsxWorkbook(
   settings?: XlsxParseSettings,
 ): Promise<XlsxParsedWorkbook> {
   const arrayBuffer = await file.arrayBuffer();
-  const [{ Workbook }, luckyexcelMod, imageUtils] = await Promise.all([
-    import('exceljs'),
-    // @ts-expect-error — luckyexcel ships without TypeScript types
-    import('luckyexcel'),
-    import('./xlsx-image-utils'),
-  ]);
-  const transformExcelToLucky = luckyexcelMod.default.transformExcelToLucky;
-  const { extractImagesFromWorksheet, convertRawImagesToFortuneSheet } =
-    imageUtils;
+  const transformExcelToLucky = LuckyExcel.transformExcelToLucky;
 
   const warnings: XlsxImportWarning[] = [];
   const generatedSheetIds: string[] = [];

--- a/src/editor/utils/xlsx-import-pipeline.ts
+++ b/src/editor/utils/xlsx-import-pipeline.ts
@@ -1,0 +1,1220 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import SSF from 'ssf';
+import type { Sheet } from '@sheet-engine/react';
+import {
+  compactImportedSheetFormatting,
+  internImportedDataVerification,
+} from './import-compaction';
+import type { RawSheetImage } from './xlsx-image-utils';
+import { normalizeImportedHyperlinkCellV } from './xlsx-hyperlink-inline';
+
+/**
+ * Pure xlsx parse/decorate/compact pipeline. No DOM, no React, no Yjs, no UI —
+ * it runs identically on the main thread and inside the dsheet worker, so the
+ * worker path and the inline fallback can never diverge. UI concerns (toasts,
+ * custom sheet-id generators, the ydoc write) live in use-xlsx-import-impl.
+ */
+
+/** Predefined option colors for data validation dropdowns (when XLSX has no color). */
+const DATA_VERIFICATION_OPTION_COLORS = [
+  '228, 232, 237', // Light Gray
+  '219, 233, 236', // White
+  '244, 217, 227', // Pink
+  '247, 229, 207', // Peach
+  '217, 234, 244', // Blue
+  '222, 239, 222', // Green
+  '239, 239, 239', // Light Green
+  '244, 230, 230', // Rose
+  '247, 239, 217', // Yellow
+  '230, 230, 244', // Purple
+  '217, 244, 244', // Cyan
+  '244, 239, 234', // Cream
+];
+const DEFAULT_OPTION_COLOR = DATA_VERIFICATION_OPTION_COLORS[0]; // Light Gray
+
+const CHECKBOX_PAIRS: [string, string][] = [
+  ['true', 'false'],
+  ['yes', 'no'],
+  ['1', '0'],
+];
+
+function isCheckboxPair(a: string, b: string): boolean {
+  const la = a.toLowerCase();
+  const lb = b.toLowerCase();
+  return CHECKBOX_PAIRS.some(([x, y]) => la === x && lb === y);
+}
+
+export function generateImportSheetId(): string {
+  if (
+    typeof crypto !== 'undefined' &&
+    typeof crypto.randomUUID === 'function'
+  ) {
+    return crypto.randomUUID();
+  }
+
+  return `sheet-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+function richTextRunsToPlainText(ctS: unknown): string | null {
+  if (!Array.isArray(ctS) || ctS.length === 0) return null;
+  const text = ctS.map((seg) => String((seg as any)?.v ?? '')).join('');
+  const trimmed = text.trim();
+  return trimmed ? text : null;
+}
+
+function excelishBooleanText(v: boolean): 'TRUE' | 'FALSE' {
+  return v ? 'TRUE' : 'FALSE';
+}
+
+/** Build dataVerification color string from option count: use color list only when options ≤ 12; if more, use only grey (first) repeated. */
+function buildDataVerificationColor(optionCount: number): string {
+  if (optionCount <= 0) return DEFAULT_OPTION_COLOR;
+  if (optionCount > DATA_VERIFICATION_OPTION_COLORS.length) {
+    return Array(optionCount).fill(DEFAULT_OPTION_COLOR).join(', ');
+  }
+  return DATA_VERIFICATION_OPTION_COLORS.slice(0, optionCount).join(', ');
+}
+
+/** Parse Excel A1-style address to 0-based row and column. e.g. "A1" -> { row: 0, col: 0 }, "B10" -> { row: 9, col: 1 } */
+function parseA1Address(address: string): { row: number; col: number } | null {
+  const match = address.match(/^([A-Z]+)(\d+)$/i);
+  if (!match) return null;
+  const letters = match[1].toUpperCase();
+  const digits = match[2];
+  let col1Based = 0;
+  for (let i = 0; i < letters.length; i++) {
+    col1Based = col1Based * 26 + (letters.charCodeAt(i) - 64);
+  }
+  const row = parseInt(digits, 10) - 1;
+  const col = col1Based - 1;
+  return { row, col };
+}
+
+/** Map ExcelJS DataValidation to project dataVerification entry (row_column key format) */
+function excelDataValidationToSheetEntry(
+  address: string,
+  dv: {
+    type?: string;
+    formulae?: any[];
+    prompt?: string;
+    showInputMessage?: boolean;
+    allowBlank?: boolean;
+  },
+): { rowColKey: string; entry: Record<string, unknown> } | null {
+  const parsed = parseA1Address(address);
+  if (!parsed) return null;
+  const { row, col } = parsed;
+  const rowColKey = `${row}_${col}`;
+
+  const rawFormula =
+    Array.isArray(dv.formulae) && dv.formulae.length > 0
+      ? String(dv.formulae[0])
+          .replace(/^["']|["']$/g, '')
+          .replace(/["']/g, '')
+      : '';
+  const parts = rawFormula
+    .split(',')
+    .map((s: string) => s.trim())
+    .filter(Boolean);
+
+  let type = dv.type === 'list' ? 'dropdown' : dv.type || 'dropdown';
+  let value1 = rawFormula;
+  let value2 = '';
+
+  if (
+    dv.type === 'list' &&
+    parts.length === 2 &&
+    isCheckboxPair(parts[0], parts[1])
+  ) {
+    type = 'checkbox';
+    value1 = parts[0];
+    value2 = parts[1];
+  }
+
+  // When no color is preset (e.g. from XLSX): one color per option; use predefined list up to 12, then Light Gray for the rest
+  const optionCount =
+    type === 'checkbox' ? 1 : value1 ? value1.split(',').length : 0;
+  const color = buildDataVerificationColor(optionCount || 1);
+
+  const entry: Record<string, unknown> = {
+    type,
+    type2: '',
+    rangeTxt: address,
+    value1,
+    value2,
+    validity: '',
+    remote: false,
+    prohibitInput: dv.type === 'list',
+    hintShow: Boolean(dv.showInputMessage),
+    hintValue: dv.prompt ?? '',
+    color,
+    checked: false,
+  };
+  return { rowColKey, entry };
+}
+
+/** Parse Excel range ref (e.g. "A1:A500" or "A1") to 0-based row/column ranges */
+function parseRefToRange(
+  ref: string,
+): { row: [number, number]; column: [number, number] } | null {
+  const parts = ref.split(':');
+  const start = parseA1Address(parts[0].trim());
+  if (!start) return null;
+  const end = parts.length > 1 ? parseA1Address(parts[1].trim()) : start;
+  if (!end) return null;
+  return {
+    row: [Math.min(start.row, end.row), Math.max(start.row, end.row)],
+    column: [Math.min(start.col, end.col), Math.max(start.col, end.col)],
+  };
+}
+
+/** Parse one or more Excel refs separated by space/comma into 0-based ranges. */
+function parseRefToRanges(
+  ref: string,
+): { row: [number, number]; column: [number, number] }[] {
+  return String(ref || '')
+    .split(/[,\s]+/)
+    .map((x) => x.trim())
+    .filter(Boolean)
+    .map((part) => parseRefToRange(part))
+    .filter(
+      (r): r is { row: [number, number]; column: [number, number] } => !!r,
+    );
+}
+
+/** Build project cellrange from one or more refs (row/column 0-based). */
+function buildCellrange(ref: string): unknown[] | null {
+  const ranges = parseRefToRanges(ref);
+  if (!ranges.length) return null;
+  return ranges.map((range) => {
+    const [r0, r1] = range.row;
+    const [c0, c1] = range.column;
+    return {
+      left: 0,
+      width: 104,
+      top: 0,
+      height: 23,
+      left_move: 0,
+      width_move: 104,
+      top_move: 0,
+      height_move: 11999,
+      row: [r0, r1],
+      column: [c0, c1],
+      row_focus: r0,
+      column_focus: c0,
+      column_select: true,
+    };
+  });
+}
+
+/** Map ExcelJS dxf style to project format (textColor, cellColor, bold, italic, underline, strikethrough) */
+function dxfStyleToFormat(style: {
+  font?: {
+    color?: { argb?: string };
+    bold?: boolean;
+    italic?: boolean;
+    underline?: boolean;
+  } | null;
+  fill?: {
+    type?: string;
+    pattern?: string;
+    fgColor?: { argb?: string };
+  } | null;
+}): {
+  textColor: string;
+  cellColor: string;
+  bold: boolean;
+  italic: boolean;
+  underline: boolean;
+  strikethrough: boolean;
+} {
+  const defaultFormat = {
+    textColor: '#000000',
+    cellColor: '#ffffff',
+    bold: false,
+    italic: false,
+    underline: false,
+    strikethrough: false,
+  };
+  if (!style) return defaultFormat;
+  const font = style.font;
+  const fill = style.fill;
+  let textColor = defaultFormat.textColor;
+  let cellColor = defaultFormat.cellColor;
+  if (font?.color?.argb) {
+    const a = font.color.argb;
+    textColor = '#' + (a.length >= 6 ? a.slice(-6) : a);
+  }
+  if (
+    fill?.type === 'pattern' &&
+    fill.pattern === 'solid' &&
+    fill.fgColor?.argb
+  ) {
+    const a = fill.fgColor.argb;
+    cellColor = '#' + (a.length >= 6 ? a.slice(-6) : a);
+  }
+  return {
+    textColor,
+    cellColor,
+    bold: Boolean(font?.bold),
+    italic: Boolean(font?.italic),
+    underline: Boolean(font?.underline),
+    strikethrough: false,
+  };
+}
+
+/**
+ * Extract the text argument from a SEARCH(...) formula (Google/Excel "text contains").
+ * Handles Google's SEARCH(("ab"),(C1)) and standard SEARCH("ab",A1). One regex pass, no loops.
+ */
+function extractTextFromSearchFormula(formula: string | undefined): string {
+  if (!formula || typeof formula !== 'string') return '';
+  const s = formula
+    .trim()
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, '&')
+    .replace(/^=/, '');
+  // SEARCH(("text"), or SEARCH("text", or SEARCH( ( "text" ) , – allow optional parens/spaces before first quote
+  const m = s.match(/(?:^|[^A-Z])SEARCH\s*\([\s(]*"((?:[^"]|"")*)"/i);
+  if (m) return (m[1] ?? '').replace(/""/g, '"');
+  const m2 = s.match(/(?:^|[^A-Z])SEARCH\s*\([\s(]*'([^']*)'/i);
+  if (m2) return m2[1] ?? '';
+  return '';
+}
+
+/** Fallback: extract first quoted string from a formula (supports "" escaping). */
+function extractFirstQuotedText(formula: string | undefined): string {
+  if (!formula || typeof formula !== 'string') return '';
+  const s = formula
+    .trim()
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/^=/, '');
+  const m = s.match(/"((?:[^"]|"")*)"/);
+  if (m) return (m[1] ?? '').replace(/""/g, '"');
+  const m2 = s.match(/'([^']*)'/);
+  if (m2) return m2[1] ?? '';
+  return '';
+}
+
+/**
+ * Google Sheets often stores text CF as expression formulas.
+ * Detect and map common text-oriented expressions to project condition names.
+ */
+function mapExpressionTextCf(
+  formula: string | undefined,
+): { conditionName: string; conditionValue: string[] } | null {
+  if (!formula || typeof formula !== 'string') return null;
+  const f = formula.trim().toUpperCase();
+  const text =
+    extractTextFromSearchFormula(formula) || extractFirstQuotedText(formula);
+  if (!text) return null;
+
+  // contains / not contains
+  if (f.includes('SEARCH(')) {
+    if (f.includes('ISERROR(SEARCH(') || f.includes('NOTNUMBER(SEARCH(')) {
+      return { conditionName: 'textDoesNotContain', conditionValue: [text] };
+    }
+    return { conditionName: 'textContains', conditionValue: [text] };
+  }
+  // starts with
+  if (f.includes('LEFT(')) {
+    return { conditionName: 'textStartsWith', conditionValue: [text] };
+  }
+  // ends with
+  if (f.includes('RIGHT(')) {
+    return { conditionName: 'textEndsWith', conditionValue: [text] };
+  }
+  // exact text check
+  if (f.includes('EXACT(') || f.includes('="')) {
+    return { conditionName: 'textExactly', conditionValue: [text] };
+  }
+  return null;
+}
+
+/** Map ExcelJS cfRule type/operator to project conditionName; return null if unsupported */
+function excelCfTypeToConditionName(
+  type: string,
+  operator?: string,
+  opts?: {
+    percent?: boolean;
+    bottom?: boolean;
+    rank?: number;
+    aboveAverage?: boolean;
+    text?: string;
+    timePeriod?: string;
+  },
+): { conditionName: string; conditionValue: string[] } | null {
+  const t = (type || '').toLowerCase();
+  if (t === 'cellis') {
+    const op = (operator || '').toLowerCase();
+    if (op === 'greaterthan')
+      return { conditionName: 'greaterThan', conditionValue: [] };
+    if (op === 'greaterthanorequal')
+      return { conditionName: 'greaterThanOrEqual', conditionValue: [] };
+    if (op === 'lessthan')
+      return { conditionName: 'lessThan', conditionValue: [] };
+    if (op === 'lessthanorequal')
+      return { conditionName: 'lessThanOrEqual', conditionValue: [] };
+    if (op === 'equal') return { conditionName: 'equal', conditionValue: [] };
+    if (op === 'notequal')
+      return { conditionName: 'notEqual', conditionValue: [] };
+    if (op === 'between')
+      return { conditionName: 'between', conditionValue: [] };
+    if (op === 'notbetween')
+      return { conditionName: 'notBetween', conditionValue: [] };
+    return null;
+  }
+  if (
+    t === 'containstext' ||
+    t === 'notcontainstext' ||
+    t === 'beginswith' ||
+    t === 'endswith' ||
+    t === 'containsblanks' ||
+    t === 'notcontainsblanks'
+  ) {
+    const op = (operator ?? '').toLowerCase();
+    if (t === 'containsblanks' || op === 'containsblanks')
+      return { conditionName: 'empty', conditionValue: [''] };
+    if (t === 'notcontainsblanks' || op === 'notcontainsblanks')
+      return { conditionName: 'notEmpty', conditionValue: [''] };
+    if (
+      t === 'notcontainstext' ||
+      op === 'notcontainstext' ||
+      op === 'notcontains'
+    )
+      return { conditionName: 'textDoesNotContain', conditionValue: [] };
+    if (t === 'beginswith' || op === 'beginswith')
+      return { conditionName: 'textStartsWith', conditionValue: [] };
+    if (t === 'endswith' || op === 'endswith')
+      return { conditionName: 'textEndsWith', conditionValue: [] };
+    if (op === 'equal')
+      return { conditionName: 'textExactly', conditionValue: [] };
+    const text = opts?.text ?? '';
+    return {
+      conditionName: 'textContains',
+      conditionValue: text ? [text] : [],
+    };
+  }
+  if (t === 'duplicatevalues')
+    return { conditionName: 'duplicateValue', conditionValue: ['0'] };
+  if (t === 'uniquevalues')
+    return { conditionName: 'duplicateValue', conditionValue: ['1'] };
+  if (t === 'top10') {
+    const rank = opts?.rank ?? 10;
+    if (opts?.percent && opts?.bottom)
+      return {
+        conditionName: 'last10_percent',
+        conditionValue: [String(rank)],
+      };
+    if (opts?.percent)
+      return { conditionName: 'top10_percent', conditionValue: [String(rank)] };
+    if (opts?.bottom)
+      return { conditionName: 'last10', conditionValue: [String(rank)] };
+    return { conditionName: 'top10', conditionValue: [String(rank)] };
+  }
+  if (t === 'aboveaverage') {
+    if (opts?.aboveAverage === false)
+      return { conditionName: 'belowAverage', conditionValue: [] };
+    return { conditionName: 'aboveAverage', conditionValue: [] };
+  }
+  if (t === 'timeperiod') {
+    const tp = (opts?.timePeriod ?? '').toLowerCase();
+    if (tp === 'today' || tp === 'tomorrow' || tp === 'yesterday') {
+      return {
+        conditionName: 'dateIs',
+        conditionValue: [`preset:${tp}`, '', 'DD/MM/YYYY'],
+      };
+    }
+    if (tp === 'last7days') {
+      return {
+        conditionName: 'dateIs',
+        conditionValue: ['preset:pastWeek', '', 'DD/MM/YYYY'],
+      };
+    }
+    if (tp === 'lastmonth') {
+      return {
+        conditionName: 'dateIs',
+        conditionValue: ['preset:pastMonth', '', 'DD/MM/YYYY'],
+      };
+    }
+    if (tp === 'lastyear') {
+      return {
+        conditionName: 'dateIs',
+        conditionValue: ['preset:pastYear', '', 'DD/MM/YYYY'],
+      };
+    }
+    return null;
+  }
+  return null;
+}
+
+/** One ExcelJS conditional format rule -> one luckysheet_conditionformat_save entry, or null if unsupported */
+function excelCfRuleToLuckysheet(
+  ref: string,
+  rule: {
+    type?: string;
+    operator?: string;
+    formulae?: string[];
+    style?: Record<string, unknown>;
+    text?: string;
+    timePeriod?: string;
+    percent?: boolean;
+    bottom?: boolean;
+    rank?: number;
+    aboveAverage?: boolean;
+  },
+): Record<string, unknown> | null {
+  if (!rule.type) return null;
+
+  // Text CF: Google often puts text only in formulae and leaves `text` empty.
+  let resolvedText = (rule.text ?? '').trim();
+  const firstFormula =
+    Array.isArray(rule.formulae) && rule.formulae[0]
+      ? String(rule.formulae[0])
+      : undefined;
+
+  // Google may export text CF as expression formulas; detect these before enum mapping.
+  const expressionMapped =
+    (rule.type.toLowerCase() === 'expression' ||
+      rule.type.toLowerCase() === 'customformula') &&
+    mapExpressionTextCf(firstFormula);
+  if (expressionMapped) {
+    const cellrange = buildCellrange(ref);
+    if (!cellrange) return null;
+    const format = dxfStyleToFormat(rule.style as any);
+    return {
+      type: 'default',
+      cellrange,
+      format: {
+        textColor: format.textColor,
+        cellColor: format.cellColor,
+        bold: format.bold,
+        italic: format.italic,
+        underline: format.underline,
+        strikethrough: format.strikethrough,
+      },
+      conditionName: expressionMapped.conditionName,
+      conditionRange: [],
+      conditionValue: expressionMapped.conditionValue,
+    };
+  }
+
+  if (
+    (rule.type === 'containsText' ||
+      rule.type === 'notContainsText' ||
+      rule.type === 'beginsWith' ||
+      rule.type === 'endsWith') &&
+    !resolvedText
+  ) {
+    resolvedText = extractTextFromSearchFormula(firstFormula);
+    if (!resolvedText) {
+      resolvedText = extractFirstQuotedText(firstFormula);
+    }
+  }
+
+  const mapped = excelCfTypeToConditionName(rule.type, rule.operator, {
+    percent: rule.percent,
+    bottom: rule.bottom,
+    rank: rule.rank,
+    aboveAverage: rule.aboveAverage,
+    text: resolvedText || rule.text,
+    timePeriod: rule.timePeriod,
+  });
+  if (!mapped) return null;
+
+  let conditionValue: string[];
+  if (
+    rule.type === 'cellIs' &&
+    Array.isArray(rule.formulae) &&
+    rule.formulae.length > 0
+  ) {
+    conditionValue = rule.formulae.map((f) => String(f ?? ''));
+  } else if (
+    mapped.conditionName === 'empty' ||
+    mapped.conditionName === 'notEmpty'
+  ) {
+    conditionValue = [''];
+  } else if (
+    rule.type === 'containsText' ||
+    rule.type === 'notContainsText' ||
+    rule.type === 'beginsWith' ||
+    rule.type === 'endsWith'
+  ) {
+    conditionValue = resolvedText
+      ? [resolvedText]
+      : extractFirstQuotedText(firstFormula)
+        ? [extractFirstQuotedText(firstFormula)]
+        : [];
+  } else {
+    conditionValue = mapped.conditionValue.map((v) =>
+      v == null ? '' : String(v),
+    );
+  }
+
+  const cellrange = buildCellrange(ref);
+  if (!cellrange) return null;
+
+  const format = dxfStyleToFormat(rule.style as any);
+
+  return {
+    type: 'default',
+    cellrange,
+    format: {
+      textColor: format.textColor,
+      cellColor: format.cellColor,
+      bold: format.bold,
+      italic: format.italic,
+      underline: format.underline,
+      strikethrough: format.strikethrough,
+    },
+    conditionName: mapped.conditionName,
+    conditionRange: [],
+    conditionValue,
+  };
+}
+
+export type XlsxImportWarning =
+  | { code: 'tables-unsupported' }
+  | { code: 'filters-unsupported' };
+
+export type XlsxParseSettings = {
+  /** Workbook default column width in px (from the live workbook settings, if any). */
+  workbookDefaultColWidth?: number;
+  /** Workbook default row height in px (from the live workbook settings, if any). */
+  workbookDefaultRowHeight?: number;
+};
+
+export type XlsxParsedWorkbook = {
+  /** Decorated + compacted sheets, ready for the ydoc write. */
+  sheets: Sheet[];
+  /** Workbook name from luckyexcel info (extension not yet stripped). */
+  workbookName: string;
+  /** UI warnings to replay on the main thread (toasts/onWarning). */
+  warnings: XlsxImportWarning[];
+  /** Sheet ids this pipeline generated — the caller may remap them with a custom generator. */
+  generatedSheetIds: string[];
+};
+
+export async function parseXlsxWorkbook(
+  file: File,
+  settings?: XlsxParseSettings,
+): Promise<XlsxParsedWorkbook> {
+  const arrayBuffer = await file.arrayBuffer();
+  const [{ Workbook }, luckyexcelMod, imageUtils] = await Promise.all([
+    import('exceljs'),
+    // @ts-expect-error — luckyexcel ships without TypeScript types
+    import('luckyexcel'),
+    import('./xlsx-image-utils'),
+  ]);
+  const transformExcelToLucky = luckyexcelMod.default.transformExcelToLucky;
+  const { extractImagesFromWorksheet, convertRawImagesToFortuneSheet } =
+    imageUtils;
+
+  const warnings: XlsxImportWarning[] = [];
+  const generatedSheetIds: string[] = [];
+  /** dataVerification per sheet: sheetIndex -> { row_column: entry } */
+  const dataVerificationBySheet: Record<
+    number,
+    Record<string, Record<string, unknown>>
+  > = {};
+  /** conditional formatting per sheet: sheetIndex -> luckysheet_conditionformat_save array */
+  const conditionFormatBySheet: Record<number, Record<string, unknown>[]> = {};
+  let unsupportedFilterWarningReported = false;
+
+  const workbook = new Workbook();
+  await workbook.xlsx.load(arrayBuffer as any);
+
+  const workbookDefaultFontSize: number | undefined = (workbook as any).model
+    ?.styles?.fonts?.[0]?.size;
+  // Extract hyperlinks, freeze info, cell formatting, and data validation from all worksheets
+  const hyperlinksBySheet: Record<
+    number,
+    Record<string, { linkType: string; linkAddress: string }[]>
+  > = {};
+  const frozenBySheet: Record<
+    number,
+    {
+      type:
+        | 'row'
+        | 'column'
+        | 'both'
+        | 'rangeRow'
+        | 'rangeColumn'
+        | 'rangeBoth';
+      range: { row_focus: number; column_focus: number };
+    }
+  > = {};
+  const cellStylesBySheet: Record<
+    number,
+    Record<
+      string,
+      {
+        bl?: number;
+        it?: number;
+        fs?: number;
+        ff?: string;
+        fc?: string;
+        bg?: string;
+        un?: number;
+      }
+    >
+  > = {};
+  // Raw image data keyed by 0-based sheet index.
+  // Pixel positions are deferred to sheets.map where FortuneSheet
+  // column/row dimensions are available.
+  const imagesBySheet: Record<number, RawSheetImage[]> = {};
+
+  workbook.eachSheet((ws, sheetIndex) => {
+    const idx = sheetIndex - 1; // exceljs is 1-based
+
+    // Hyperlinks
+    const sheetHyperlinks: Record<
+      string,
+      { linkType: string; linkAddress: string }[]
+    > = {};
+
+    // Freeze panes from worksheet views
+    const views = ws.views;
+    if (views && views.length > 0) {
+      const view = views[0];
+      if (view.state === 'frozen') {
+        const xSplit = view.xSplit || 0;
+        const ySplit = view.ySplit || 0;
+        let type: 'rangeRow' | 'rangeColumn' | 'rangeBoth' | null = null;
+        if (xSplit > 0 && ySplit > 0) type = 'rangeBoth';
+        else if (ySplit > 0) type = 'rangeRow';
+        else if (xSplit > 0) type = 'rangeColumn';
+        if (type) {
+          frozenBySheet[idx] = {
+            type,
+            range: {
+              row_focus: ySplit - 1,
+              column_focus: xSplit - 1,
+            },
+          };
+        }
+      }
+    }
+
+    // Cell-level formatting and hyperlinks
+    const styles: Record<
+      string,
+      {
+        bl?: number;
+        it?: number;
+        fs?: number;
+        ff?: string;
+        fc?: string;
+        bg?: string;
+        un?: number;
+      }
+    > = {};
+    ws.eachRow({ includeEmpty: false }, (row, rowNumber) => {
+      row.eachCell({ includeEmpty: false }, (cell, colNumber) => {
+        const key = `${rowNumber - 1}_${colNumber - 1}`;
+
+        if (cell.hyperlink) {
+          sheetHyperlinks[key] = [
+            {
+              linkType: 'webpage',
+              linkAddress: cell.hyperlink,
+            },
+          ];
+        }
+
+        // Extract cell formatting
+        const font = cell.style?.font;
+        const fill = cell.style?.fill;
+        const cellStyle: Record<string, string | number> = {};
+
+        if (font) {
+          if (font.bold) cellStyle.bl = 1;
+          if (font.italic) cellStyle.it = 1;
+          if (font.underline) cellStyle.un = 1;
+          const effectiveFontSize = font.size ?? workbookDefaultFontSize;
+          if (effectiveFontSize) cellStyle.fs = effectiveFontSize;
+          if (font.name) cellStyle.ff = font.name;
+          if (font.color?.argb) {
+            const argb = font.color.argb;
+            const hex = '#' + argb.substring(argb.length - 6);
+            cellStyle.fc = hex;
+          }
+        }
+        if (
+          fill?.type === 'pattern' &&
+          fill.pattern === 'solid' &&
+          fill.fgColor
+        ) {
+          if (fill.fgColor.argb) {
+            const argb = fill.fgColor.argb;
+            const hex = '#' + argb.substring(argb.length - 6);
+            cellStyle.bg = hex;
+          }
+        }
+        if (Object.keys(cellStyle).length > 0) {
+          styles[key] = cellStyle;
+        }
+      });
+    });
+
+    if (Object.keys(sheetHyperlinks).length > 0) {
+      hyperlinksBySheet[idx] = sheetHyperlinks;
+    }
+    if (Object.keys(styles).length > 0) {
+      cellStylesBySheet[idx] = styles;
+    }
+
+    // Extract images — pixel positions are deferred to sheets.map
+    const sheetImages = extractImagesFromWorksheet(ws, workbook);
+    if (sheetImages.length > 0) imagesBySheet[idx] = sheetImages;
+
+    const wsTables = (ws as any).tables;
+    if (wsTables && Object.keys(wsTables).length > 0) {
+      warnings.push({ code: 'tables-unsupported' });
+    }
+
+    // Extract data validation for this sheet (row_column keys for dataVerification)
+    const dvModel = (
+      ws as { dataValidations?: { model?: Record<string, unknown> } }
+    ).dataValidations?.model;
+    if (dvModel && typeof dvModel === 'object') {
+      const sheetDv: Record<string, Record<string, unknown>> = {};
+      for (const [address, dv] of Object.entries(dvModel)) {
+        const dvObj = dv as {
+          type?: string;
+          formulae?: unknown[];
+          prompt?: string;
+          showInputMessage?: boolean;
+          allowBlank?: boolean;
+        };
+        const result = excelDataValidationToSheetEntry(address, dvObj);
+        if (result) sheetDv[result.rowColKey] = result.entry;
+      }
+      if (Object.keys(sheetDv).length > 0) {
+        dataVerificationBySheet[idx] = sheetDv;
+      }
+    }
+
+    // Extract conditional formatting for this sheet (luckysheet_conditionformat_save)
+    const cfs = (
+      ws as {
+        conditionalFormattings?: { ref: string; rules: unknown[] }[];
+      }
+    ).conditionalFormattings;
+    if (Array.isArray(cfs) && cfs.length > 0) {
+      const sheetCf: Record<string, unknown>[] = [];
+      for (const cf of cfs) {
+        const ref = cf.ref;
+        const rules = cf.rules || [];
+        for (const rule of rules) {
+          const r = rule as {
+            type?: string;
+            operator?: string;
+            formulae?: string[];
+            style?: Record<string, unknown>;
+            text?: string;
+            timePeriod?: string;
+            percent?: boolean;
+            bottom?: boolean;
+            rank?: number;
+            aboveAverage?: boolean;
+          };
+          console.log('[XLSX CF RAW]', {
+            ref,
+            type: r.type,
+            operator: r.operator,
+            formulae: r.formulae,
+            text: r.text,
+            timePeriod: r.timePeriod,
+            percent: r.percent,
+            bottom: r.bottom,
+            rank: r.rank,
+            aboveAverage: r.aboveAverage,
+          });
+          const entry = r.type ? excelCfRuleToLuckysheet(ref, r) : null;
+          if (!entry) {
+            console.log('[XLSX CF MAPPED] skipped', {
+              ref,
+              type: r.type,
+              operator: r.operator,
+              formulae: r.formulae,
+              text: r.text,
+            });
+          } else {
+            console.log('[XLSX CF MAPPED] accepted', entry);
+          }
+          if (entry) sheetCf.push(entry);
+        }
+      }
+      if (sheetCf.length > 0) {
+        conditionFormatBySheet[idx] = sheetCf;
+      }
+    }
+
+    const autoFilter = (ws as any).autoFilter;
+    if (autoFilter && !unsupportedFilterWarningReported) {
+      unsupportedFilterWarningReported = true;
+      warnings.push({ code: 'filters-unsupported' });
+    }
+  }); // close workbook.eachSheet
+
+  const exportJson = await new Promise<{
+    sheets: Sheet[];
+    info?: { name?: string };
+  }>((resolve) => transformExcelToLucky(file, resolve));
+
+  let sheets = exportJson.sheets;
+  sheets.forEach((sheet, sheetIndex) => {
+    const sheetDv = dataVerificationBySheet[sheetIndex];
+    if (sheetDv && Object.keys(sheetDv).length > 0) {
+      sheet.dataVerification = sheetDv;
+    }
+    // Always set condition format: use our imported rules or empty array. Avoids leaving
+    // stale/malformed rules from luckyexcel (e.g. type "colorGradation" with undefined format)
+    // which cause "Cannot read properties of undefined (reading '0')" in fortune-core ConditionFormat.js
+    const sheetCf = conditionFormatBySheet[sheetIndex];
+    sheet.luckysheet_conditionformat_save =
+      Array.isArray(sheetCf) && sheetCf.length > 0 ? sheetCf : [];
+  });
+
+  const isDateCache = new Map<string, boolean>();
+  sheets = sheets.map((sheet, sheetIndex) => {
+    const lastCell = sheet?.celldata?.[sheet.celldata.length - 1];
+
+    const lastRow = lastCell?.r ?? 0;
+    const lastCol = lastCell?.c ?? 0;
+
+    sheet.row = Math.max(lastRow, 500);
+    sheet.column = Math.max(lastCol, 36);
+
+    if (!sheet.id) {
+      sheet.id = generateImportSheetId();
+      generatedSheetIds.push(sheet.id);
+    }
+    // Attach freeze pane info
+    if (frozenBySheet[sheetIndex]) {
+      sheet.frozen = frozenBySheet[sheetIndex];
+    }
+    // Attach hyperlinks extracted from exceljs for this sheet
+    if (hyperlinksBySheet[sheetIndex]) {
+      sheet.hyperlink = {
+        ...(sheet.hyperlink || {}),
+        ...hyperlinksBySheet[sheetIndex],
+      };
+    }
+    // Correct column widths before image position conversion so that
+    // nativeColToPx uses the same MDW=7 values the grid renders with.
+    if (sheet.config?.columnlen) {
+      const corrected: Record<string, number> = {};
+      Object.entries(sheet.config.columnlen).forEach(([col, px]) => {
+        const wch = (Number(px) - 5) / 8 + 0.83;
+        corrected[col] = Math.round(wch * 7 + 5);
+      });
+      sheet.config.columnlen = corrected;
+    }
+
+    const defaultColPx = Math.round(Number(sheet.defaultColWidth) || 73);
+    if (sheet.config?.columnlen) {
+      const filteredCols: Record<string, number> = {};
+      Object.entries(sheet.config.columnlen).forEach(([col, w]) => {
+        if (Math.abs(Math.round(Number(w)) - defaultColPx) > 1) {
+          filteredCols[col] = Number(w);
+        }
+      });
+      sheet.config.columnlen = filteredCols;
+    }
+
+    // Drop rowlen entries at or near the default row height so Fortune
+    // uses its own default for rows the user never manually resized.
+    // Also done before image conversion so nativeRowToPx uses the
+    // same rowlen the grid renders with.
+    if (sheet.config?.rowlen) {
+      const defaultRowPx = Math.round(Number(sheet.defaultRowHeight) || 21);
+      const filtered: Record<string, number> = {};
+      Object.entries(sheet.config.rowlen).forEach(([row, h]) => {
+        if (Math.abs(Math.round(Number(h)) - defaultRowPx) > 1) {
+          filtered[row] = Number(h);
+        }
+      });
+      sheet.config.rowlen = filtered;
+    }
+
+    if (sheet.config?.customHeight) {
+      const keep = new Set<string>(
+        Object.keys((sheet.config.rowlen as any) || {}),
+      );
+      const next: Record<string, number> = {};
+      Object.entries(sheet.config.customHeight).forEach(([row, flag]) => {
+        if (keep.has(row) && Number(flag) === 1) {
+          next[row] = 1;
+        }
+      });
+      sheet.config.customHeight = next;
+    }
+
+    // Attach images — convert fractional col/row to pixels using
+    // FortuneSheet's actual column/row dimensions so positions match.
+    if (imagesBySheet[sheetIndex]) {
+      const imageDefaultColPx =
+        Number(sheet.defaultColWidth) ||
+        Number(settings?.workbookDefaultColWidth) ||
+        99;
+      const imageDefaultRowPx =
+        Number(sheet.defaultRowHeight) ||
+        Number(settings?.workbookDefaultRowHeight) ||
+        21;
+      sheet.images = convertRawImagesToFortuneSheet(
+        imagesBySheet[sheetIndex],
+        sheet,
+        imageDefaultColPx,
+        imageDefaultRowPx,
+      );
+    }
+    // Apply cell formatting from exceljs (hyperlink styling, bold, italic, bg, etc.)
+    // Also fix date cells: set ct.t="d", coerce v to number, compute m
+    const hlKeys = hyperlinksBySheet[sheetIndex];
+    const styleKeys = cellStylesBySheet[sheetIndex];
+    const calcChain: { r: number; c: number; id: string }[] = [];
+    const pushCalcChainOnce = (r: number, c: number) => {
+      const k = `${r}_${c}`;
+      if ((pushCalcChainOnce as any)._seen == null) {
+        (pushCalcChainOnce as any)._seen = new Set<string>();
+      }
+      const seen = (pushCalcChainOnce as any)._seen as Set<string>;
+      if (seen.has(k)) return;
+      seen.add(k);
+      calcChain.push({ r, c, id: sheet.id as string });
+    };
+    // Built during the celldata loop below; only allocated when merges exist
+    const celldataMap = sheet.config?.merge
+      ? new Map<string, { r: number; c: number; v: Record<string, unknown> }>()
+      : null;
+    if (sheet.celldata) {
+      for (const cell of sheet.celldata) {
+        const key = `${cell.r}_${cell.c}`;
+        celldataMap?.set(
+          key,
+          cell as {
+            r: number;
+            c: number;
+            v: Record<string, unknown>;
+          },
+        );
+        if (cell.v) {
+          if (cell.v.f) {
+            const fStr = String(cell.v.f);
+            if (!fStr.startsWith('=')) {
+              cell.v.f = `=${fStr}`;
+            }
+          }
+          // Mark formula cells so FortuneSheet recalculates them on dependency change.
+          // Keep cached m/v so the workbook shows something during the remount phase;
+          // schedulePostImportFormulaRecalc will overwrite them once the engine runs.
+          if (cell.v.f && cell.v.ct?.t !== 'd') {
+            cell.v.ct = { ...(cell.v.ct ?? {}), t: 'str' };
+            pushCalcChainOnce(cell.r, cell.c);
+          }
+          // Apply formatting extracted from exceljs
+          if (styleKeys?.[key]) {
+            const styleFromExcel = styleKeys[key] as Record<string, unknown>;
+            const hasHyperlink = !!hlKeys?.[key];
+            if (hasHyperlink) {
+              // Hyperlink cells: avoid root-level fc/un inheritance.
+              const { fc: _fc, un: _un, ...rest } = styleFromExcel;
+              void _fc;
+              void _un;
+              Object.assign(cell.v, rest);
+            } else {
+              Object.assign(cell.v, styleFromExcel);
+            }
+          }
+          // Hyperlink cells: shared normalization (single ct.s run, styles on segment only).
+          if (hlKeys?.[key] && !cell.v.f) {
+            const hyperlink = hlKeys[key][0];
+            if (hyperlink) {
+              normalizeImportedHyperlinkCellV(
+                cell.v as Record<string, unknown>,
+                hyperlink,
+              );
+            }
+          }
+          // Fix date cells: luckyexcel leaves ct.t unset and v as a string
+          const fa = cell.v.ct?.fa;
+          const normalizedFa =
+            typeof fa === 'string' ? fa.trim().toLowerCase() : '';
+          const isGeneralLikeFormat =
+            normalizedFa === 'general' || cell.v.ct?.t === 'g';
+          const isTextLikeFormat = normalizedFa === '@' || cell.v.ct?.t === 's';
+          if (fa && !isDateCache.has(fa)) {
+            isDateCache.set(fa, SSF.is_date(fa));
+          }
+
+          if (!cell.v.f && fa && isDateCache.get(fa)) {
+            const numV =
+              typeof cell.v.v === 'string' ? parseFloat(cell.v.v) : cell.v.v;
+            if (typeof numV === 'number' && !isNaN(numV)) {
+              try {
+                cell.v.v = numV;
+                cell.v.m = SSF.format(fa, numV);
+                cell.v.ct = { ...cell.v.ct, t: 'd' };
+              } catch {
+                // malformed format string — leave cell as-is
+              }
+            }
+            // luckyexcel stores numeric values as strings (e.g. "59.0"); parse to number and recompute m so integers don't display with a trailing ".0"
+          } else if (
+            !cell.v.f &&
+            typeof cell.v.v === 'string' &&
+            !isTextLikeFormat &&
+            !isGeneralLikeFormat
+          ) {
+            const rawStringValue = (cell.v.v as string).trim();
+            const isStrictNumericString =
+              /^[-+]?(?:\d+\.?\d*|\.\d+)(?:[eE][-+]?\d+)?$/.test(
+                rawStringValue,
+              );
+            if (isStrictNumericString) {
+              const numV = Number(rawStringValue);
+              if (!isFinite(numV)) {
+                continue;
+              }
+              cell.v.v = numV;
+              if (cell.v.ht == null) {
+                cell.v.ht = 2;
+              }
+              if (!fa) {
+                cell.v.m = String(numV);
+              } else {
+                try {
+                  cell.v.m = SSF.format(fa, numV);
+                } catch {
+                  // malformed format string — leave m as-is
+                }
+              }
+            }
+          } else if (
+            !cell.v.f &&
+            typeof cell.v.v === 'number' &&
+            isFinite(cell.v.v) &&
+            cell.v.ct?.t !== 's' &&
+            cell.v.ct?.t !== 'd'
+          ) {
+            if (cell.v.ht == null) {
+              cell.v.ht = 2;
+            }
+          }
+
+          // Ensure non-empty imported cells always have a display mask `m`.
+          // Filter-by-values uses `m` for display; when it is missing, values collapse to (Null).
+          if (
+            !cell.v.f &&
+            (cell.v.m === undefined || cell.v.m === null) &&
+            cell.v.ct?.t !== 'd'
+          ) {
+            const richText = richTextRunsToPlainText(cell.v.ct?.s);
+            const rawV = cell.v.v;
+            const isBlankLike = rawV == null || String(rawV).trim() === '';
+            if (!isBlankLike) {
+              // Prefer rich text if present (hyperlinks are typically stored in ct.s).
+              if (richText != null) {
+                cell.v.m = richText;
+              } else if (typeof rawV === 'boolean') {
+                cell.v.m = excelishBooleanText(rawV);
+              } else if (typeof rawV === 'number' && isFinite(rawV)) {
+                const fa2 = cell.v.ct?.fa;
+                if (
+                  typeof fa2 === 'string' &&
+                  fa2 &&
+                  isDateCache.get(fa2) === false
+                ) {
+                  try {
+                    cell.v.m = SSF.format(fa2, rawV);
+                  } catch {
+                    cell.v.m = String(rawV);
+                  }
+                } else {
+                  cell.v.m = String(rawV);
+                }
+              } else if (typeof rawV === 'object') {
+                // Unknown complex value; leave `m` unset to avoid misleading text.
+              } else {
+                cell.v.m = String(rawV);
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // Normalize formula cells in the data grid (luckyexcel may populate sheet.data
+    // in addition to sheet.celldata). Keep cached m/v for display during remount.
+    if (Array.isArray((sheet as any).data)) {
+      const data = (sheet as any).data as any[][];
+      for (let r = 0; r < data.length; r++) {
+        const row = data[r];
+        if (!Array.isArray(row)) continue;
+        for (let c = 0; c < row.length; c++) {
+          const v = row[c];
+          if (!v || typeof v !== 'object') continue;
+          if (!v.f) continue;
+
+          const fStr = String(v.f);
+          if (!fStr.startsWith('=')) v.f = `=${fStr}`;
+          if (v.ct?.t !== 'd') {
+            v.ct = { ...(v.ct ?? {}), t: 'str' };
+            pushCalcChainOnce(r, c);
+          }
+        }
+      }
+    }
+
+    sheet.calcChain = calcChain;
+
+    // luckyexcel only sets config.merge but not cell-level mc properties.
+    // FortuneSheet's canvas renderer needs mc on each cell in the merge range.
+    // celldataMap was built during the celldata loop above (single pass).
+    if (celldataMap && sheet.config?.merge && sheet.celldata) {
+      for (const merge of Object.values(sheet.config.merge) as {
+        r: number;
+        c: number;
+        rs: number;
+        cs: number;
+      }[]) {
+        const { r, c, rs, cs } = merge;
+        for (let dr = 0; dr < rs; dr++) {
+          for (let dc = 0; dc < cs; dc++) {
+            const key = `${r + dr}_${c + dc}`;
+            const isAnchor = dr === 0 && dc === 0;
+            let cell = celldataMap.get(key);
+            if (!cell) {
+              cell = {
+                r: r + dr,
+                c: c + dc,
+                v: isAnchor ? { mc: { r, c, rs, cs } } : { mc: { r, c } },
+              };
+              sheet.celldata.push(cell as never);
+              celldataMap.set(key, cell);
+            } else {
+              if (!cell.v) cell.v = {};
+              cell.v.mc = isAnchor ? { r, c, rs, cs } : { r, c };
+            }
+          }
+        }
+      }
+    }
+
+    internImportedDataVerification(sheet);
+    compactImportedSheetFormatting(sheet);
+
+    return sheet;
+  });
+
+  return {
+    sheets,
+    workbookName: exportJson?.info?.name ?? file.name ?? '',
+    warnings,
+    generatedSheetIds,
+  };
+}

--- a/src/sheet-engine/core/paste/paste-border-utils.ts
+++ b/src/sheet-engine/core/paste/paste-border-utils.ts
@@ -34,3 +34,59 @@ export function filterMeaningfulBorderSides(sides: {
   if (isMeaningfulBorderSide(sides.b)) out.b = sides.b;
   return out;
 }
+
+/** Drop junk borderInfo entries. Returns undefined when unchanged. */
+export function compactBorderInfo(
+  borderInfo: any[] | undefined,
+): any[] | undefined {
+  if (!borderInfo?.length) return undefined;
+
+  const next: any[] = [];
+  let changed = false;
+
+  for (let i = 0; i < borderInfo.length; i += 1) {
+    const entry = borderInfo[i];
+    if (!entry || typeof entry !== 'object') {
+      changed = true;
+      continue;
+    }
+
+    if (entry.rangeType === 'cell' && entry.value) {
+      const filtered = filterMeaningfulBorderSides(entry.value);
+      if (!filtered.l && !filtered.r && !filtered.t && !filtered.b) {
+        changed = true;
+        continue;
+      }
+      if (
+        filtered.l !== entry.value.l ||
+        filtered.r !== entry.value.r ||
+        filtered.t !== entry.value.t ||
+        filtered.b !== entry.value.b
+      ) {
+        next.push({ ...entry, value: { ...entry.value, ...filtered } });
+        changed = true;
+      } else {
+        next.push(entry);
+      }
+      continue;
+    }
+
+    if (entry.rangeType === 'range') {
+      if (entry.borderType === 'border-none') {
+        next.push(entry);
+        continue;
+      }
+      const style = Number(entry.style);
+      if (!style || isTransparentBorderColor(String(entry.color ?? ''))) {
+        changed = true;
+        continue;
+      }
+      next.push(entry);
+      continue;
+    }
+
+    next.push(entry);
+  }
+
+  return changed ? next : undefined;
+}

--- a/src/sheet-engine/core/types.ts
+++ b/src/sheet-engine/core/types.ts
@@ -225,6 +225,8 @@ export type Sheet = {
   luckysheet_conditionformat_save?: any[];
   luckysheet_alternateformat_save?: any[];
   dataVerification?: any;
+  /** Interned dataVerification entries; per-cell map may hold numeric refs into this list. */
+  dataVerificationDefs?: any[];
   conditionRules?: ConditionRulesProps;
   hyperlink?: Record<string, HyperlinkEntry | HyperlinkEntry[]>;
   dynamicArray_compute?: any;

--- a/src/sheet-engine/core/types.ts
+++ b/src/sheet-engine/core/types.ts
@@ -134,6 +134,8 @@ export type SheetConfig = {
   borderInfo?: any[]; // 边框
   /** Range-level cell formatting for empty cells (toolbar bulk format). */
   cellFormatRanges?: CellFormatRange[];
+  /** Background compaction revision (celldata + borderInfo); synced via Yjs. */
+  sheetCompactionRev?: number;
   authority?: any;
   rowReadOnly?: Record<number, number>;
   colReadOnly?: Record<number, number>;

--- a/src/worker/dsheet-worker-client.ts
+++ b/src/worker/dsheet-worker-client.ts
@@ -1,0 +1,78 @@
+import * as Comlink from 'comlink';
+// Inline worker: the whole worker bundle (exceljs, luckyexcel, pipeline) is
+// embedded in the package output and spawned from a blob URL at runtime, so
+// consuming apps need no worker asset wiring. Their CSP must allow
+// `worker-src blob:` (or the `child-src`/`script-src` fallback).
+import DsheetWorkerCtor from './dsheet-worker?worker&inline';
+import type { DsheetWorkerApi } from './dsheet-worker';
+
+export type { DsheetWorkerApi };
+
+/** Terminate the worker after this long without an active or new task. */
+const WORKER_IDLE_TERMINATE_MS = 30_000;
+
+let active: {
+  worker: Worker;
+  api: Comlink.Remote<DsheetWorkerApi>;
+} | null = null;
+let idleTimer: ReturnType<typeof setTimeout> | null = null;
+let pendingTaskCount = 0;
+
+export const isDsheetWorkerSupported = (): boolean =>
+  typeof window !== 'undefined' && typeof Worker !== 'undefined';
+
+const clearIdleTimer = (): void => {
+  if (idleTimer != null) {
+    clearTimeout(idleTimer);
+    idleTimer = null;
+  }
+};
+
+export const terminateDsheetWorker = (): void => {
+  clearIdleTimer();
+  if (active) {
+    active.api[Comlink.releaseProxy]();
+    active.worker.terminate();
+    active = null;
+  }
+};
+
+const scheduleIdleTerminate = (): void => {
+  clearIdleTimer();
+  idleTimer = setTimeout(() => {
+    if (pendingTaskCount === 0) terminateDsheetWorker();
+  }, WORKER_IDLE_TERMINATE_MS);
+};
+
+const ensureWorker = (): Comlink.Remote<DsheetWorkerApi> => {
+  if (!active) {
+    const worker = new DsheetWorkerCtor();
+    active = { worker, api: Comlink.wrap<DsheetWorkerApi>(worker) };
+  }
+  return active.api;
+};
+
+/**
+ * Run a task on the shared dsheet worker. The worker is spawned lazily,
+ * reused across tasks, and terminated after 30s idle (a parse can hold
+ * hundreds of MB of transient allocations — terminating returns them to
+ * the OS immediately). Callers must handle rejection and fall back to the
+ * main-thread equivalent; a worker that failed is torn down so the next
+ * task starts from a fresh one.
+ */
+export async function runDsheetWorkerTask<T>(
+  task: (api: Comlink.Remote<DsheetWorkerApi>) => Promise<T>,
+): Promise<T> {
+  const api = ensureWorker();
+  clearIdleTimer();
+  pendingTaskCount += 1;
+  try {
+    return await task(api);
+  } catch (error) {
+    terminateDsheetWorker();
+    throw error;
+  } finally {
+    pendingTaskCount -= 1;
+    if (pendingTaskCount === 0 && active) scheduleIdleTerminate();
+  }
+}

--- a/src/worker/dsheet-worker.ts
+++ b/src/worker/dsheet-worker.ts
@@ -1,0 +1,24 @@
+import * as Comlink from 'comlink';
+import {
+  parseXlsxWorkbook,
+  type XlsxParseSettings,
+  type XlsxParsedWorkbook,
+} from '../editor/utils/xlsx-import-pipeline';
+
+/**
+ * The dsheet offload worker. One worker, many tasks: add new offloadable
+ * operations as methods on this object — the client (dsheet-worker-client)
+ * exposes them through the same Comlink proxy. Everything reachable from
+ * here must stay DOM/React/Yjs-free; the worker bundle is built standalone
+ * and inlined into the package, so main-bundle externals do not exist here.
+ */
+const dsheetWorkerApi = {
+  parseXlsxWorkbook: (
+    file: File,
+    settings?: XlsxParseSettings,
+  ): Promise<XlsxParsedWorkbook> => parseXlsxWorkbook(file, settings),
+};
+
+export type DsheetWorkerApi = typeof dsheetWorkerApi;
+
+Comlink.expose(dsheetWorkerApi);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,18 @@ export default defineConfig({
       ),
     },
   },
+  // The dsheet worker builds as a separate self-contained graph: iife output
+  // inlines its dynamic imports AND ignores the library externals below, so
+  // exceljs/luckyexcel are bundled into the worker blob (a blob worker cannot
+  // resolve bare imports).
+  worker: {
+    format: 'iife',
+    rollupOptions: {
+      output: {
+        inlineDynamicImports: true,
+      },
+    },
+  },
   build: {
     lib: {
       name: 'dsheet',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,18 +16,11 @@ export default defineConfig({
       ),
     },
   },
-  // The dsheet worker builds as a separate self-contained graph: iife output
-  // inlines its dynamic imports AND ignores the library externals below, so
-  // exceljs/luckyexcel are bundled into the worker blob (a blob worker cannot
-  // resolve bare imports).
-  worker: {
-    format: 'iife',
-    rollupOptions: {
-      output: {
-        inlineDynamicImports: true,
-      },
-    },
-  },
+  // The dsheet worker builds as a separate self-contained graph (default iife
+  // format, library externals below do not apply), so exceljs/luckyexcel are
+  // bundled into the worker blob — a blob worker cannot resolve bare imports.
+  // The worker graph must stay single-chunk: no dynamic imports anywhere in
+  // the pipeline, or iife worker output breaks (Vercel demo build).
   build: {
     lib: {
       name: 'dsheet',


### PR DESCRIPTION
Google Sheets exports materialize style-only empty cells and per-cell
dropdown validations; imports now strip format-only cells into
config.cellFormatRanges and intern duplicate dataVerification entries
into dataVerificationDefs (numeric refs, expanded at read boundaries).