### PR TITLE
fix: comment indicator disappears on empty cells after refresh (viewer side)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fileverse-dev/dsheet",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fileverse-dev/dsheet",
-      "version": "4.0.2",
+      "version": "4.0.3",
       "dependencies": {
         "@fileverse-dev/dsheets-templates": "^0.0.29",
         "@fileverse-dev/formulajs": "^4.4.53",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fileverse-dev/dsheet",
   "private": false,
   "description": "DSheet",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "main": "dist/index.es.js",
   "module": "dist/index.es.js",
   "exports": {

--- a/src/editor/utils/apply-comment-markers.ts
+++ b/src/editor/utils/apply-comment-markers.ts
@@ -53,8 +53,7 @@ export const applyCommentMarkers = <T>(
   (sheets as any[]).forEach((sheet, index) => {
     if (!sheet) return;
     const sheetKey = (sheet.id as any)?.toString?.() ?? String(index);
-    const sheetOrder =
-      typeof sheet.order === 'number' ? sheet.order : index;
+    const sheetOrder = typeof sheet.order === 'number' ? sheet.order : index;
 
     const markerFor = (row: number, col: number) => {
       const comment = resolveComment(
@@ -67,8 +66,28 @@ export const applyCommentMarkers = <T>(
       );
       // Fresh object per cell: `ps` is mutated by the library on interaction
       // (isShow/left/top/…), so cells must not share one reference.
-      return comment && allowComments ? { ...CELL_COMMENT_DEFAULT_VALUE } : undefined;
+      return comment && allowComments
+        ? { ...CELL_COMMENT_DEFAULT_VALUE }
+        : undefined;
     };
+
+    // Find every cell on this sheet that has a comment. We need this list
+    // because an empty cell has no cell object, so the loops below can't add
+    // the comment marker to it unless we know it should have one.
+    const commentedCells: Array<[number, number]> = [];
+    if (commentData && allowComments) {
+      const prefixes = new Set([sheetKey, String(sheetOrder), String(index)]);
+      Object.keys(commentData as Record<string, unknown>).forEach((key) => {
+        const parts = key.split('_');
+        if (parts.length !== 3) return; // not a cell comment (e.g. WITHOUT_CELL_*)
+        const [prefix, rowStr, colStr] = parts;
+        if (!prefixes.has(prefix)) return; // comment is for a different sheet
+        const row = Number(rowStr);
+        const col = Number(colStr);
+        if (Number.isNaN(row) || Number.isNaN(col)) return;
+        commentedCells.push([row, col]);
+      });
+    }
 
     // Active sheet: dense data grid.
     if (Array.isArray(sheet.data)) {
@@ -78,6 +97,20 @@ export const applyCommentMarkers = <T>(
           cell.ps = markerFor(row, col);
         });
       });
+      // An empty cell is `null`, so the loop above skipped it. Create a tiny
+      // cell object just to hold the comment marker, so the indicator shows
+      // again after a refresh.
+      commentedCells.forEach(([row, col]) => {
+        const rowArr = (sheet.data as any[])[row];
+        if (!rowArr) return; // cell is outside the current grid — skip
+        if (rowArr[col]) return; // real cell exists, already handled above
+        // This cell is only for showing the marker. A viewer's own comment
+        // never reaches here again (their comment isn't saved to the doc). It
+        // only fires for an empty cell whose comment lives in the host's
+        // comment store but not in the doc — a marker-only cell, which the
+        // doc already treats as a valid thing to keep.
+        rowArr[col] = { ps: { ...CELL_COMMENT_DEFAULT_VALUE } };
+      });
       return;
     }
 
@@ -86,6 +119,19 @@ export const applyCommentMarkers = <T>(
       sheet.celldata.forEach((entry: any) => {
         if (!entry?.v) return;
         entry.v.ps = markerFor(entry.r, entry.c);
+      });
+      // Same empty-cell problem here: if a commented cell has no entry, add a
+      // small entry that only carries the marker.
+      const present = new Set(
+        (sheet.celldata as any[]).map((e) => `${e?.r}_${e?.c}`),
+      );
+      commentedCells.forEach(([row, col]) => {
+        if (present.has(`${row}_${col}`)) return; // entry already exists
+        (sheet.celldata as any[]).push({
+          r: row,
+          c: col,
+          v: { ps: { ...CELL_COMMENT_DEFAULT_VALUE } },
+        });
       });
     }
   });


### PR DESCRIPTION
When a viewer added a comment to an empty cell, the little comment indicator on that cell vanished after a page refresh even though the comment was still there in the comments panel. Comments on cells that already had content worked fine.

Why it happened: the indicator needs a cell to attach to. Cells with content already exist when the page reloads, so the indicator comes back. Empty cells don't exist until something is put in them, so on reload there was nothing to attach the indicator to, and it disappeared.

The fix: on reload, for any empty cell that has a comment, we now recreate a minimal placeholder so the indicator shows up again. The comment data itself is unchanged - this only restores the visual marker.