### PR TITLE
chore: move react/react-dom to peerDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,8 +29,6 @@
         "luckyexcel": "^1.0.1",
         "numeral": "^2.0.6",
         "papaparse": "^5.5.2",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
         "regenerator-runtime": "^0.14.1",
         "socket.io-client": "^4.8.3",
         "tailwindcss-animate": "^1.0.7",
@@ -66,6 +64,8 @@
         "postcss": "^8.4.38",
         "postinstall-postinstall": "^2.1.0",
         "prettier": "^3.4.2",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
         "sass": "^1.77.2",
         "tailwindcss": "^3.4.3",
         "typescript": "^5.2.2",
@@ -74,6 +74,8 @@
         "yjs": "13.6.30"
       },
       "peerDependencies": {
+        "react": "^18.2.0 || ^19.0.0",
+        "react-dom": "^18.2.0 || ^19.0.0",
         "yjs": ">=13.6.30 <14"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fileverse-dev/dsheet",
-  "version": "4.0.6",
+  "version": "4.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fileverse-dev/dsheet",
-      "version": "4.0.6",
+      "version": "4.1.0",
       "dependencies": {
         "@fileverse-dev/dsheets-templates": "^0.0.31",
         "@fileverse-dev/formulajs": "4.4.54",

--- a/package.json
+++ b/package.json
@@ -79,8 +79,6 @@
     "luckyexcel": "^1.0.1",
     "numeral": "^2.0.6",
     "papaparse": "^5.5.2",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
     "regenerator-runtime": "^0.14.1",
     "socket.io-client": "^4.8.3",
     "tailwindcss-animate": "^1.0.7",
@@ -94,6 +92,8 @@
     "y-protocols": "^1.0.6"
   },
   "peerDependencies": {
+    "react": "^18.2.0 || ^19.0.0",
+    "react-dom": "^18.2.0 || ^19.0.0",
     "yjs": ">=13.6.30 <14"
   },
   "devDependencies": {
@@ -119,6 +119,8 @@
     "postcss": "^8.4.38",
     "postinstall-postinstall": "^2.1.0",
     "prettier": "^3.4.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "sass": "^1.77.2",
     "tailwindcss": "^3.4.3",
     "typescript": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fileverse-dev/dsheet",
   "private": false,
   "description": "DSheet",
-  "version": "4.0.6",
+  "version": "4.1.0",
   "main": "dist/index.es.js",
   "module": "dist/index.es.js",
   "exports": {


### PR DESCRIPTION
Same change as the ddoc PR: react/react-dom were in dependencies, which under a react 19 consumer would nest a second react 18 copy (invalid hook calls). Moved to peerDependencies (^18 || ^19), re-added to devDependencies for local dev — matching the existing yjs pattern. Vite build already externalizes react; dist unchanged.

Bumps version to **4.1.0** for the release workflow. No merge-order dependency — the ui dep range (^5.1.9) tolerates the upcoming ui 5.3.0.

Part of the react 19 / next 16 upgrade track.