### PR TITLE
Keep comments following row/column drag, insert, and delete.

### DIFF
--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -1,11 +1,12 @@
 import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
-import { DSheetEditor, WorkbookInstance, CommentAction } from '../../src/index';
+import { DSheetEditor, WorkbookInstance, CommentAction, remapCommentAnchors } from '../../src/index';
 import type {
   CollaborationProps,
   CollabState,
   CommentThread,
   CommentActionParams,
+  CommentAnchorMove,
 } from '../../src/index';
 import {
   Button,
@@ -110,6 +111,10 @@ function App() {
     },
     [dsheetId],
   );
+
+  const onCellPositionsChanged = useCallback((move: CommentAnchorMove) => {
+    setCommentsData((prev) => remapCommentAnchors(prev, move));
+  }, []);
 
   const onCommentAction = useCallback((a: CommentActionParams) => {
     setCommentsData((prev) => {
@@ -454,6 +459,7 @@ function App() {
                   commentsData,
                   onSendComment,
                   onCommentAction,
+                  onCellPositionsChanged,
                   userName: 'demo-user',
                   currentUserAddress: 'demo-user',
                   isOwner: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fileverse-dev/dsheet",
-  "version": "4.1.0-cmt-1",
+  "version": "4.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fileverse-dev/dsheet",
-      "version": "4.1.0-cmt-1",
+      "version": "4.1.1",
       "dependencies": {
         "@fileverse-dev/dsheets-templates": "^0.0.31",
         "@fileverse-dev/formulajs": "4.4.54",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fileverse-dev/dsheet",
-  "version": "4.1.0",
+  "version": "4.1.0-cmt-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fileverse-dev/dsheet",
-      "version": "4.1.0",
+      "version": "4.1.0-cmt-1",
       "dependencies": {
         "@fileverse-dev/dsheets-templates": "^0.0.31",
         "@fileverse-dev/formulajs": "4.4.54",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fileverse-dev/dsheet",
   "private": false,
   "description": "DSheet",
-  "version": "4.1.0-cmt-1",
+  "version": "4.1.1",
   "main": "dist/index.es.js",
   "module": "dist/index.es.js",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fileverse-dev/dsheet",
   "private": false,
   "description": "DSheet",
-  "version": "4.1.0",
+  "version": "4.1.0-cmt-1",
   "main": "dist/index.es.js",
   "module": "dist/index.es.js",
   "exports": {

--- a/src/editor/components/comments/comment-cell-popup.tsx
+++ b/src/editor/components/comments/comment-cell-popup.tsx
@@ -23,6 +23,8 @@ export const CommentCellUI: React.FC<CommentCellUIProps> = ({
   dragHandler,
   isHover = false,
   disabled = false,
+  isAuthenticated = true,
+  unauthenticatedFallback,
 }) => {
   const [isCommentHovered, setIsCommentHovered] = useState(false);
   const cellKey = `${sheetId}_${row}_${col}`;
@@ -43,6 +45,11 @@ export const CommentCellUI: React.FC<CommentCellUIProps> = ({
   // No comment yet — nothing to show in read-only mode (can't add one).
   if (!comment && disabled) {
     return null;
+  }
+
+  // No comment yet — join/login before composing.
+  if (!comment && !isAuthenticated) {
+    return <>{unauthenticatedFallback ?? null}</>;
   }
 
   // No comment yet — always show the input regardless of hover/click,
@@ -102,7 +109,7 @@ export const CommentCellUI: React.FC<CommentCellUIProps> = ({
       >
         <p className="text-sm font-medium color-text-default">Comments</p>
         <div className="min-h-[26px]">
-          {onAction && isCommentHovered && !disabled && (
+          {onAction && isCommentHovered && !disabled && isAuthenticated && (
             <CommentActionsDropdown
               comment={comment}
               onAction={(action) => {
@@ -130,7 +137,7 @@ export const CommentCellUI: React.FC<CommentCellUIProps> = ({
         <CommentItem
           comment={comment}
           isHovered={true}
-          onAction={disabled ? undefined : onAction}
+          onAction={disabled || !isAuthenticated ? undefined : onAction}
           ownerAddress={ownerAddress}
           currentUserAddress={currentUserAddress}
           isOwner={isOwner}
@@ -153,6 +160,10 @@ export const CommentCellUI: React.FC<CommentCellUIProps> = ({
                 Comments are not available during Real-Time Collaboration
               </span>
             </div>
+          </div>
+        ) : !isAuthenticated ? (
+          <div className="space-sm color-bg-secondary">
+            {unauthenticatedFallback ?? null}
           </div>
         ) : comment.isResolved ? (
           <div className="space-sm color-bg-secondary">

--- a/src/editor/components/comments/comment-sidebar.tsx
+++ b/src/editor/components/comments/comment-sidebar.tsx
@@ -113,8 +113,10 @@ export const CommentsContent: React.FC<CommentsContentProps> = ({
   );
 
   // When disabled (e.g. during real-time collaboration), comments are visible
-  // but read-only: input + actions are blocked.
+  // but read-only: input + actions are blocked. Unauthenticated visitors with
+  // comment permission can still read existing threads.
   const enableCollaboration = disabled;
+  const canWrite = !disabled && isAuthenticated;
 
   React.useEffect(() => {
     try {
@@ -279,14 +281,6 @@ export const CommentsContent: React.FC<CommentsContentProps> = ({
     });
   };
 
-  if (!isAuthenticated) {
-    return (
-      <div className="flex h-full w-full items-center justify-center">
-        {unauthenticatedFallback ?? null}
-      </div>
-    );
-  }
-
   return (
     <div>
       {/* Filter Bar */}
@@ -388,7 +382,7 @@ export const CommentsContent: React.FC<CommentsContentProps> = ({
                   comment={comment as CommentThread}
                   sheetName={sheetInfo?.displayName}
                   cellReference={cellReference}
-                  onAction={disabled ? undefined : onCommentAction}
+                  onAction={canWrite ? onCommentAction : undefined}
                   ownerAddress={ownerAddress}
                   currentUserAddress={currentUserAddress}
                   isOwner={isOwner}
@@ -416,18 +410,22 @@ export const CommentsContent: React.FC<CommentsContentProps> = ({
                           </span>
                         </div>
                       </div>
-                    ) : (
+                    ) : canWrite ? (
                       <CommentInput
                         id="sidebar-comment-edit"
                         onSend={handleSendReply(key)}
                         autoFocus
                         backgroundColor="white"
                       />
-                    )}
+                    ) : !isAuthenticated ? (
+                      <div className="mt-3">{unauthenticatedFallback}</div>
+                    ) : null}
                   </div>
                 ) : comment.replies.length <= 0 ? (
                   <div className="pl-[32px]">
-                    {isCommentClick.has(key) && !comment.isResolved && (
+                    {canWrite &&
+                      isCommentClick.has(key) &&
+                      !comment.isResolved && (
                       <CommentInput
                         id="sidebar-comment-edit"
                         onSend={handleSendReply(key)}
@@ -452,6 +450,7 @@ export const CommentsContent: React.FC<CommentsContentProps> = ({
                     )}
                   </div>
                 ) : (
+                  canWrite &&
                   !comment.isResolved &&
                   comment.replies.length > 0 && (
                     <Button
@@ -482,6 +481,10 @@ export const CommentsContent: React.FC<CommentsContentProps> = ({
 
       {/* New Comment Section */}
       <div className="border-t p-2 space-lg">
+        {!isAuthenticated ? (
+          unauthenticatedFallback ?? null
+        ) : (
+          <>
         <div className="flex justify-start items-center gap-2">
           <div className="flex items-center justify-center w-6 h-6">
             <Avatar key={userName} size="md" content="text" alt={userName} />
@@ -508,6 +511,8 @@ export const CommentsContent: React.FC<CommentsContentProps> = ({
           removeCancelButton={true}
           className="mt-2"
         />
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/editor/components/editor-workbook.tsx
+++ b/src/editor/components/editor-workbook.tsx
@@ -59,6 +59,14 @@ import {
   closeCellCommentPopup,
 } from '../utils/cell-comment-marker';
 import { getCurrentSheetIdSafe } from '../utils/sheet-editor-safe';
+import {
+  commentKeyMovesById,
+  remapCommentAnchors,
+} from '../utils/remap-comment-anchors';
+import {
+  applyYdocCommentAnchors,
+  writeCommentAnchorsToYdoc,
+} from '../utils/comment-anchors-ydoc';
 // import { useEditorData } from '../hooks/use-editor-data';
 // Use the types defined in types.ts
 type OnboardingHandler = OnboardingHandlerType;
@@ -142,6 +150,7 @@ const EditorWorkbookComponent: React.FC<EditorWorkbookProps> = ({
     openApiKeyModal,
     onDataBlockEvent,
     smartContract,
+    handleOnChangePortalUpdate,
   } = useEditor();
 
   const localUserEditRef = useRef(false);
@@ -155,6 +164,33 @@ const EditorWorkbookComponent: React.FC<EditorWorkbookProps> = ({
   commentsConfigRef.current = commentsConfig;
   const hasComments = !!commentsConfig;
   const allowComments = !commentsConfig?.disabled;
+
+  // One-shot: if this doc has no published comment anchors yet, seed them
+  // from the owner's current keys (including locally remapped ones) so the
+  // next save/publish is visible to viewers. Skip once the map exists so
+  // adding a comment does not dirty ydoc.
+  useEffect(() => {
+    if (isReadOnly || !commentsConfig?.commentsData) return;
+    if (collabEnabled && !collabIsOwner) return;
+    const ydoc = ydocRef.current;
+    if (!ydoc) return;
+    writeCommentAnchorsToYdoc({
+      ydoc,
+      dsheetId,
+      commentsData: commentsConfig.commentsData,
+      handleContentPortal: handleOnChangePortalUpdate,
+      skipUnmapped: true,
+    });
+  }, [
+    isReadOnly,
+    collabEnabled,
+    collabIsOwner,
+    commentsConfig?.commentsData,
+    dsheetId,
+    ydocRef,
+    handleOnChangePortalUpdate,
+    syncStatus,
+  ]);
 
   const removeCommentFromCell = useCallback(
     (row: number, col: number) => {
@@ -180,8 +216,12 @@ const EditorWorkbookComponent: React.FC<EditorWorkbookProps> = ({
       const isAuthed = cfg.isAuthenticated ?? true;
       const sheetId = getCurrentSheetIdSafe(sheetEditorRef);
       const key = `${sheetId}_${row}_${col}`;
-      const comment = cfg.commentsData[key];
-      if (!isAuthed) return cfg.unauthenticatedFallback ?? null;
+      const commentsData = applyYdocCommentAnchors(
+        cfg.commentsData,
+        ydocRef.current,
+        dsheetId,
+      );
+      const comment = commentsData[key];
       return (
         <CommentCellUI
           row={row}
@@ -200,6 +240,8 @@ const EditorWorkbookComponent: React.FC<EditorWorkbookProps> = ({
           dragHandler={dragHandler}
           isHover={isHover}
           disabled={cfg.disabled}
+          isAuthenticated={isAuthed}
+          unauthenticatedFallback={cfg.unauthenticatedFallback}
         />
       );
     };
@@ -310,8 +352,6 @@ const EditorWorkbookComponent: React.FC<EditorWorkbookProps> = ({
       delete window.setForceRenderEditor;
     };
   }, [isReadOnly]);
-
-  const { handleOnChangePortalUpdate } = useEditor();
 
   // Initialize XLSX import functionality
   const { handleXLSXUpload } = useXLSXImport({
@@ -609,6 +649,23 @@ const EditorWorkbookComponent: React.FC<EditorWorkbookProps> = ({
           // @ts-ignore Fortune Hooks type misses this runtime hook.
           afterHideChanges: handleAfterHideChanges,
           afterColRowChanges: handleAfterColRowChanges,
+          afterCommentAnchorMove: (move) => {
+            const cfg = commentsConfigRef.current;
+            const current = applyYdocCommentAnchors(
+              cfg?.commentsData ?? {},
+              ydocRef.current,
+              dsheetId,
+            );
+            const remapped = remapCommentAnchors(current, move);
+            writeCommentAnchorsToYdoc({
+              ydoc: ydocRef.current,
+              dsheetId,
+              commentsData: remapped,
+              keyMoves: commentKeyMovesById(current, remapped),
+              handleContentPortal: handleOnChangePortalUpdate,
+            });
+            cfg?.onCellPositionsChanged?.(move);
+          },
           afterShowGridLinesChange: guardRemoteEcho(() => {
             syncCurrentSheetField(syncContext, 'showGridLines');
           }),
@@ -643,6 +700,7 @@ const EditorWorkbookComponent: React.FC<EditorWorkbookProps> = ({
     isAuthorized,
     dataBlockCalcFunction,
     theme,
+    handleOnChangePortalUpdate,
   ]);
 
   return React.cloneElement(workbookElement, {

--- a/src/editor/contexts/editor-context.tsx
+++ b/src/editor/contexts/editor-context.tsx
@@ -280,6 +280,12 @@ export const EditorProvider: React.FC<EditorProviderProps> = ({
     [onContentUpdate],
   );
 
+  // Same-turn ydoc writes (celldata emit, then comment anchors) must encode
+  // together. A leading persist in the middle of that stack publishes new
+  // cells with old comment positions — viewers then show data that moved and
+  // triangles that did not.
+  const portalUpdateScheduledRef = useRef(false);
+
   const rehydrateAfterCollabSyncRef = useRef<(reason: string) => boolean>(
     () => false,
   );
@@ -427,24 +433,33 @@ export const EditorProvider: React.FC<EditorProviderProps> = ({
     [handleOnChange, handleContentUpdateNotification],
   );
 
-  const handleOnChangePortalUpdate = useCallback(() => {
+  const flushPortalUpdate = useCallback(() => {
     handleOnChange();
-    // Notify hosts cheaply for local changes while preserving the legacy
-    // snapshot callback for consumers that still request sheet data.
+    handleOnChange.flush();
     handleContentUpdateNotification();
+    handleContentUpdateNotification.flush();
   }, [handleOnChange, handleContentUpdateNotification]);
+
+  const handleOnChangePortalUpdate = useCallback(() => {
+    if (portalUpdateScheduledRef.current) return;
+    portalUpdateScheduledRef.current = true;
+    queueMicrotask(() => {
+      portalUpdateScheduledRef.current = false;
+      flushPortalUpdate();
+    });
+  }, [flushPortalUpdate]);
 
   useEffect(() => {
     if (!onChange) return;
 
     const handleBeforeUnload = () => {
-      handleOnChange();
+      flushPortalUpdate();
     };
     window.addEventListener('beforeunload', handleBeforeUnload);
     return () => {
       window.removeEventListener('beforeunload', handleBeforeUnload);
     };
-  }, [onChange, handleOnChange]);
+  }, [onChange, flushPortalUpdate]);
 
   // Initialize sheet data
   const {

--- a/src/editor/dsheet-editor.tsx
+++ b/src/editor/dsheet-editor.tsx
@@ -31,6 +31,10 @@ import { useMediaQuery } from 'usehooks-ts';
 import { CommentsContent } from './components/comments/comment-sidebar';
 import { setEnsResolutionUrl } from './components/comments/ens/ens-cache';
 import { CommentsConfig } from './types/comments';
+import {
+  applyYdocCommentAnchors,
+  getCommentAnchorsYMap,
+} from './utils/comment-anchors-ydoc';
 import { SmartContractModal } from './components/smart-contract/smart-contract-modal';
 import { SmartContractListView } from './components/smart-contract/smart-contract-view-list';
 import { SmartContractReadingIntro } from './components/smart-contract/smart-contract-reading-intro';
@@ -127,6 +131,29 @@ const EditorContent = ({
     useState(0);
   const isMobile = useMediaQuery('(max-width: 840px)', { defaultValue: false });
 
+  const [commentAnchorsVersion, setCommentAnchorsVersion] = useState(0);
+  useEffect(() => {
+    const ydoc = ydocRef.current;
+    if (!ydoc || !dsheetId) return undefined;
+    const map = getCommentAnchorsYMap(ydoc, dsheetId);
+    const bump = () => setCommentAnchorsVersion((v) => v + 1);
+    map.observe(bump);
+    bump();
+    return () => {
+      map.unobserve(bump);
+    };
+  }, [dsheetId, ydocRef, syncStatus]);
+
+  const anchoredCommentsData = useMemo(
+    () =>
+      applyYdocCommentAnchors(
+        commentsConfig?.commentsData,
+        ydocRef.current,
+        dsheetId || '',
+      ),
+    [commentsConfig?.commentsData, commentAnchorsVersion, dsheetId, ydocRef],
+  );
+
   const builtInPanels: PanelConfig[] = [
     ...(smartContract.enabled
       ? [
@@ -159,7 +186,7 @@ const EditorContent = ({
             <CommentsContent
               sheetEditorRef={sheetEditorRef}
               userName={commentsConfig.userName}
-              commentsData={commentsConfig.commentsData}
+              commentsData={anchoredCommentsData}
               onSendComment={commentsConfig.onSendComment}
               onCommentAction={commentsConfig.onCommentAction}
               ownerAddress={commentsConfig.ownerAddress}

--- a/src/editor/hooks/use-editor-data.tsx
+++ b/src/editor/hooks/use-editor-data.tsx
@@ -12,6 +12,7 @@ import type { DataBlockEvent } from '../types';
 import { ySheetArrayToPlain } from '../utils/update-ydoc';
 import { migrateSheetArrayIfNeeded } from '../utils/migrate-new-yjs';
 import { applyCommentMarkers } from '../utils/apply-comment-markers';
+import { applyYdocCommentAnchors, getCommentAnchorsYMap } from '../utils/comment-anchors-ydoc';
 import {
   beginRemoteApply,
   endRemoteApplyAfterPaint,
@@ -77,6 +78,35 @@ export const useEditorData = (
   useEffect(() => {
     allowCommentsRef.current = allowComments;
   }, [allowComments]);
+
+  const commentsForMarkers = useCallback(
+    (data?: object | null) =>
+      applyYdocCommentAnchors(
+        data ?? commentDataRef.current,
+        ydocRef.current,
+        dsheetId,
+      ),
+    [dsheetId, ydocRef],
+  );
+
+  const restampCommentMarkers = useCallback((): boolean => {
+    const anchored = commentsForMarkers();
+    const allow = allowCommentsRef.current;
+    const skipEmpty = !anchored || Object.keys(anchored).length === 0;
+    const setContext = sheetEditorRef?.current?.getWorkbookSetContext?.();
+    const appliedLive = typeof setContext === 'function';
+    if (skipEmpty) return appliedLive;
+    if (!appliedLive) return false;
+    // Overlay only: mutate `ps` on the live Immer draft. Never replace
+    // luckysheetfile / currentDataRef or remount — that rewrites cell data
+    // after row/column drag and duplicates or drops values.
+    setContext((ctx: any) => {
+      if (ctx?.luckysheetfile) {
+        applyCommentMarkers(ctx.luckysheetfile, anchored, allow);
+      }
+    });
+    return true;
+  }, [commentsForMarkers, sheetEditorRef]);
 
   const { handleLiveQuery, initialiseLiveQueryData } = useLiveQuery(
     sheetEditorRef,
@@ -146,9 +176,10 @@ export const useEditorData = (
         sheetArray as Y.Array<Y.Map>,
       );
 
+      const portalAnchored = commentsForMarkers();
       applyCommentMarkers(
         newSheetData,
-        commentDataRef.current,
+        portalAnchored,
         allowCommentsRef.current,
       );
       currentDataRef.current = newSheetData;
@@ -177,47 +208,53 @@ export const useEditorData = (
     }
   }, [portalContent, collabEnabled, dsheetId, ydocRef, setForceSheetRender, initialiseLiveQueryData, setDataBlockCalcFunction]);
 
-  // Apply comment data if provided (do this before any other initialization)
+  // Stamp markers onto the live workbook. Comments often arrive before the
+  // sheet engine has mounted, so retry until getWorkbookSetContext exists.
   useEffect(() => {
-    if (!ydocRef.current || !dsheetId) {
-      return;
-    }
+    if (!dsheetId) return undefined;
     try {
-      const currentDocData = ydocRef.current.getArray(dsheetId);
-      const currentData = ySheetArrayToPlain(
-        // @ts-ignore
-        currentDocData as Y.Array<Y.Map>,
-      );
-      if (currentData.length > 0 && syncStatus === 'synced') {
-        applyCommentMarkers(currentDataRef.current, commentData, allowComments);
-
-        const setContext = sheetEditorRef?.current?.getWorkbookSetContext();
-        if (sheetEditorRef.current !== null && setContext) {
-          setContext((ctx: any) => {
-            applyCommentMarkers(ctx.luckysheetfile, commentData, allowComments);
-          });
-        } else if (syncStatus === 'synced') {
-          applyCommentMarkers(currentData, commentData, allowComments);
-          currentDataRef.current = currentData;
-          if (setForceSheetRender) {
-            setForceSheetRender((prev) => prev + 1);
-          }
+      if (restampCommentMarkers()) return undefined;
+      const hasComments =
+        !!commentData && Object.keys(commentData as object).length > 0;
+      if (!hasComments || !currentDataRef.current?.length) return undefined;
+      setForceSheetRender?.((prev) => prev + 1);
+      let tries = 0;
+      const id = window.setInterval(() => {
+        tries += 1;
+        if (restampCommentMarkers() || tries > 40) {
+          window.clearInterval(id);
         }
-      }
+      }, 100);
+      return () => window.clearInterval(id);
     } catch (error) {
       console.error('[DSheet] Error processing comment data:', error);
+      return undefined;
     }
   }, [
+    restampCommentMarkers,
     commentData,
     dsheetId,
-    ydocRef,
-    isReadOnly,
     isDataLoaded,
-    setIsDataLoaded,
     portalContent,
     allowComments,
     syncStatus,
+    setForceSheetRender,
   ]);
+
+  // Re-stamp markers when published comment anchors land in ydoc (viewer load).
+  useEffect(() => {
+    const ydoc = ydocRef.current;
+    if (!ydoc || !dsheetId) return undefined;
+    const map = getCommentAnchorsYMap(ydoc, dsheetId);
+    const restamp = () => {
+      restampCommentMarkers();
+    };
+    map.observe(restamp);
+    restamp();
+    return () => {
+      map.unobserve(restamp);
+    };
+  }, [restampCommentMarkers, dsheetId, ydocRef, syncStatus, portalContent]);
 
   // Initialize sheet data once Socket.IO collab sync reaches 'ready' for the first time.
   // The ydoc already contains the merged server state at this point.
@@ -245,7 +282,7 @@ export const useEditorData = (
       const plain = ySheetArrayToPlain(sheetArray as Y.Array<Y.Map>);
       applyCommentMarkers(
         plain,
-        commentDataRef.current,
+        commentsForMarkers(),
         allowCommentsRef.current,
       );
       currentDataRef.current = plain;
@@ -822,7 +859,7 @@ export const useEditorData = (
             const plain = ySheetArrayToPlain(sheetArray as any);
             applyCommentMarkers(
               plain,
-              commentDataRef.current,
+              commentsForMarkers(),
               allowCommentsRef.current,
             );
             currentDataRef.current = plain;
@@ -1067,7 +1104,7 @@ export const useEditorData = (
           const plain = ySheetArrayToPlain(sheetArray as any);
           applyCommentMarkers(
             plain,
-            commentDataRef.current,
+            commentsForMarkers(),
             allowCommentsRef.current,
           );
           currentDataRef.current = plain;
@@ -1274,7 +1311,7 @@ export const useEditorData = (
 
         applyCommentMarkers(
           plain,
-          commentDataRef.current,
+          commentsForMarkers(),
           allowCommentsRef.current,
         );
         currentDataRef.current = plain;

--- a/src/editor/types.ts
+++ b/src/editor/types.ts
@@ -18,6 +18,7 @@ export type {
   CommentReply,
   CommentActionParams,
   CommentsConfig,
+  CommentAnchorMove,
 } from './types/comments';
 export { CommentAction } from './types/comments';
 

--- a/src/editor/types/comments.ts
+++ b/src/editor/types/comments.ts
@@ -1,4 +1,7 @@
 import React from 'react';
+import type { CommentAnchorMove } from '../../sheet-engine/core/settings';
+
+export type { CommentAnchorMove };
 
 export interface CommentThread {
   id: string;
@@ -12,6 +15,8 @@ export interface CommentThread {
   replies: CommentReply[];
   isResolved?: boolean;
   isDeleted?: boolean;
+  /** IPFS/indexer hash — stable across local `comment-*` ids and on-chain uuids. */
+  contentHash?: string;
 }
 
 export interface CommentReply {
@@ -45,11 +50,16 @@ export interface CommentsConfig {
   commentsData: Record<string, CommentThread>; // key: `${sheetId}_${row}_${col}` or `WITHOUT_CELL_n`
   onSendComment: (key: string, textareaId: string) => void;
   onCommentAction: (action: CommentActionParams) => void;
+  /**
+   * Called after row/column drag-drop or a cell-range move so the host can
+   * remap comment keys. Use `remapCommentAnchors` from the package.
+   */
+  onCellPositionsChanged?: (move: CommentAnchorMove) => void;
   userName?: string;
   ownerAddress?: string;
   currentUserAddress?: string; // for permission author-match
   isOwner?: boolean; // owner can delete/resolve anything
-  isAuthenticated?: boolean; // default true; false → unauthenticatedFallback in the cell popup
+  isAuthenticated?: boolean; // default true; false → unauthenticatedFallback for compose only; existing threads stay visible
   unauthenticatedFallback?: React.ReactNode;
   ensResolutionUrl?: string; // mainnet RPC URL; enables ENS name + verified badge. Omit → raw names.
   disabled?: boolean;
@@ -124,6 +134,8 @@ export interface CommentCellUIProps {
   dragHandler: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
   isHover?: boolean;
   disabled?: boolean;
+  isAuthenticated?: boolean;
+  unauthenticatedFallback?: React.ReactNode;
 }
 
 export interface CommentsContentProps {

--- a/src/editor/utils/apply-comment-markers.ts
+++ b/src/editor/utils/apply-comment-markers.ts
@@ -29,17 +29,9 @@ const resolveComment = (
  * the consumer-provided `commentData`.
  *
  * `ps` is a per-client, permission-gated *view overlay* — it is NOT persisted in
- * ydoc. Every path that rebuilds sheet data from ydoc (portal load, collab sync
- * remount, remote cell edits) produces cells WITHOUT `ps`, so this must run on
- * each such snapshot or the red-triangle indicator vanishes. Because it is
- * gated on the local `allowComments` permission, it must never be written back
- * to shared ydoc state — doing so would let one viewer wipe markers for all.
- *
- * Handles both shapes:
- * - Dense `sheet.data` (the live active sheet in `luckysheetfile`).
- * - Sparse `sheet.celldata` (plain snapshots from `ySheetArrayToPlain`, and
- *   inactive sheets). `initSheetData()` converts celldata → data on activation,
- *   so `ps` set on celldata carries through.
+ * ydoc (`shouldPersistCelldataCell` ignores marker-only cells). Empty cells are
+ * `null`, so a tiny `{ ps }` object is created in the live view only so the
+ * triangle can render. Row/column drag still owns real cell data.
  *
  * Mutates in place and returns the same array.
  */
@@ -49,6 +41,12 @@ export const applyCommentMarkers = <T>(
   allowComments: boolean | undefined,
 ): T | null | undefined => {
   if (!Array.isArray(sheets)) return sheets;
+  const commentCount =
+    commentData && typeof commentData === 'object'
+      ? Object.keys(commentData as object).length
+      : 0;
+  // Empty commentData is "not loaded yet". Do not walk cells and clear `ps`.
+  if (!commentCount) return sheets;
 
   (sheets as any[]).forEach((sheet, index) => {
     if (!sheet) return;
@@ -71,17 +69,14 @@ export const applyCommentMarkers = <T>(
         : undefined;
     };
 
-    // Find every cell on this sheet that has a comment. We need this list
-    // because an empty cell has no cell object, so the loops below can't add
-    // the comment marker to it unless we know it should have one.
     const commentedCells: Array<[number, number]> = [];
     if (commentData && allowComments) {
       const prefixes = new Set([sheetKey, String(sheetOrder), String(index)]);
       Object.keys(commentData as Record<string, unknown>).forEach((key) => {
         const parts = key.split('_');
-        if (parts.length !== 3) return; // not a cell comment (e.g. WITHOUT_CELL_*)
+        if (parts.length !== 3) return;
         const [prefix, rowStr, colStr] = parts;
-        if (!prefixes.has(prefix)) return; // comment is for a different sheet
+        if (!prefixes.has(prefix)) return;
         const row = Number(rowStr);
         const col = Number(colStr);
         if (Number.isNaN(row) || Number.isNaN(col)) return;
@@ -94,22 +89,25 @@ export const applyCommentMarkers = <T>(
       sheet.data.forEach((rowArr: any[], row: number) => {
         rowArr?.forEach((cell: any, col: number) => {
           if (!cell) return;
-          cell.ps = markerFor(row, col);
+          try {
+            cell.ps = markerFor(row, col);
+          } catch {
+            // Frozen snapshot — do not clone or replace sheet data.
+          }
         });
       });
-      // An empty cell is `null`, so the loop above skipped it. Create a tiny
-      // cell object just to hold the comment marker, so the indicator shows
-      // again after a refresh.
+      // Empty cells are `null`, so the loop above skipped them. Place a
+      // view-only marker object so the triangle shows. These are not written
+      // to ydoc.
       commentedCells.forEach(([row, col]) => {
         const rowArr = (sheet.data as any[])[row];
-        if (!rowArr) return; // cell is outside the current grid — skip
-        if (rowArr[col]) return; // real cell exists, already handled above
-        // This cell is only for showing the marker. A viewer's own comment
-        // never reaches here again (their comment isn't saved to the doc). It
-        // only fires for an empty cell whose comment lives in the host's
-        // comment store but not in the doc — a marker-only cell, which the
-        // doc already treats as a valid thing to keep.
-        rowArr[col] = { ps: { ...CELL_COMMENT_DEFAULT_VALUE } };
+        if (!rowArr) return;
+        if (rowArr[col]) return;
+        try {
+          rowArr[col] = { ps: { ...CELL_COMMENT_DEFAULT_VALUE } };
+        } catch {
+          // Frozen row — skip rather than cloning the grid.
+        }
       });
       return;
     }
@@ -118,20 +116,26 @@ export const applyCommentMarkers = <T>(
     if (Array.isArray(sheet.celldata)) {
       sheet.celldata.forEach((entry: any) => {
         if (!entry?.v) return;
-        entry.v.ps = markerFor(entry.r, entry.c);
+        try {
+          entry.v.ps = markerFor(entry.r, entry.c);
+        } catch {
+          // Frozen snapshot — do not clone or replace sheet data.
+        }
       });
-      // Same empty-cell problem here: if a commented cell has no entry, add a
-      // small entry that only carries the marker.
       const present = new Set(
         (sheet.celldata as any[]).map((e) => `${e?.r}_${e?.c}`),
       );
       commentedCells.forEach(([row, col]) => {
-        if (present.has(`${row}_${col}`)) return; // entry already exists
-        (sheet.celldata as any[]).push({
-          r: row,
-          c: col,
-          v: { ps: { ...CELL_COMMENT_DEFAULT_VALUE } },
-        });
+        if (present.has(`${row}_${col}`)) return;
+        try {
+          (sheet.celldata as any[]).push({
+            r: row,
+            c: col,
+            v: { ps: { ...CELL_COMMENT_DEFAULT_VALUE } },
+          });
+        } catch {
+          // Frozen celldata — skip rather than cloning the grid.
+        }
       });
     }
   });

--- a/src/editor/utils/comment-anchors-ydoc.ts
+++ b/src/editor/utils/comment-anchors-ydoc.ts
@@ -1,0 +1,199 @@
+import * as Y from 'yjs';
+
+/** Sibling share key on the same Y.Doc as the sheet array. */
+export function getCommentAnchorsMapKey(dsheetId: string): string {
+  return `${dsheetId}:commentAnchors`;
+}
+
+export function getCommentAnchorsYMap(
+  ydoc: Y.Doc,
+  dsheetId: string,
+): Y.Map<string> {
+  return ydoc.getMap(getCommentAnchorsMapKey(dsheetId)) as Y.Map<string>;
+}
+
+export function readCommentAnchorsFromYdoc(
+  ydoc: Y.Doc | null | undefined,
+  dsheetId: string,
+): Record<string, string> {
+  if (!ydoc || !dsheetId) return {};
+  const map = getCommentAnchorsYMap(ydoc, dsheetId);
+  const anchors: Record<string, string> = {};
+  map.forEach((value, id) => {
+    if (typeof id === 'string' && typeof value === 'string' && value.length > 0) {
+      anchors[id] = value;
+    }
+  });
+  return anchors;
+}
+
+type CommentAnchorRecord = {
+  id?: string;
+  key?: string;
+  contentHash?: string;
+};
+
+function commentAliases(comment: CommentAnchorRecord | null | undefined): string[] {
+  const aliases: string[] = [];
+  if (typeof comment?.id === 'string' && comment.id.length > 0) {
+    aliases.push(comment.id);
+  }
+  if (typeof comment?.contentHash === 'string' && comment.contentHash.length > 0) {
+    aliases.push(comment.contentHash);
+  }
+  return aliases;
+}
+
+/**
+ * Re-key comments by identity first (id, then contentHash), then the comment's
+ * own current cell-key. Stale cell-key aliases that now belong to another
+ * thread must not steal or duplicate it.
+ */
+export function applyCommentAnchorMap<T extends CommentAnchorRecord>(
+  commentsData: Record<string, T> | null | undefined,
+  anchors: Record<string, string>,
+): Record<string, T> {
+  if (!commentsData) return {};
+  const anchorIds = Object.keys(anchors);
+  if (anchorIds.length === 0) return commentsData;
+
+  const next: Record<string, T> = {};
+  const seenIdentity = new Set<string>();
+  let changed = false;
+
+  for (const [key, comment] of Object.entries(commentsData)) {
+    const identity =
+      (typeof comment?.id === 'string' && comment.id) ||
+      (typeof comment?.contentHash === 'string' && comment.contentHash) ||
+      key;
+    if (seenIdentity.has(identity)) {
+      changed = true;
+      continue;
+    }
+    seenIdentity.add(identity);
+
+    const idKey =
+      typeof comment?.id === 'string' && comment.id.length > 0
+        ? anchors[comment.id]
+        : undefined;
+    const hashKey =
+      typeof comment?.contentHash === 'string' && comment.contentHash.length > 0
+        ? anchors[comment.contentHash]
+        : undefined;
+    const cellKeyAlias = anchors[key];
+    const newKey = idKey || hashKey || cellKeyAlias || key;
+
+    if (newKey !== key || comment.key !== newKey) changed = true;
+
+    if (next[newKey] && next[newKey]?.id !== comment?.id) {
+      const withoutKey = `WITHOUT_CELL_${comment?.id || identity}`;
+      next[withoutKey] = { ...comment, key: withoutKey };
+      continue;
+    }
+
+    next[newKey] = newKey === comment.key ? comment : { ...comment, key: newKey };
+  }
+
+  return changed ? next : commentsData;
+}
+
+export function applyYdocCommentAnchors<T extends CommentAnchorRecord>(
+  commentsData: Record<string, T> | object | null | undefined,
+  ydoc: Y.Doc | null | undefined,
+  dsheetId: string,
+): Record<string, T> {
+  const data = (commentsData ?? {}) as Record<string, T>;
+  if (!ydoc || !dsheetId) return data;
+  const anchors = readCommentAnchorsFromYdoc(ydoc, dsheetId);
+  return applyCommentAnchorMap(data, anchors);
+}
+
+/**
+ * Persist current commentId/contentHash → cell-key into ydoc so viewers/publish
+ * see the remapped positions. No-ops when the map already matches.
+ */
+export function writeCommentAnchorsToYdoc({
+  ydoc,
+  dsheetId,
+  commentsData,
+  handleContentPortal,
+  skipUnmapped = false,
+  keyMoves,
+}: {
+  ydoc: Y.Doc | null | undefined;
+  dsheetId: string;
+  commentsData: Record<string, CommentAnchorRecord> | null | undefined;
+  handleContentPortal?: () => void;
+  /** When the map already has entries, skip comments that are not in it yet. */
+  skipUnmapped?: boolean;
+  /** old cell-key → new cell-key so indexer keys still resolve after remap. */
+  keyMoves?: Record<string, string>;
+}): void {
+  if (!ydoc || !dsheetId || !commentsData) {
+    return;
+  }
+  const map = getCommentAnchorsYMap(ydoc, dsheetId);
+  let changed = false;
+  const existingSize = map.size;
+  ydoc.transact(() => {
+    if (keyMoves && Object.keys(keyMoves).length > 0) {
+      const occupied = new Set(
+        Object.values(commentsData)
+          .map((comment) => comment?.key)
+          .filter((key): key is string => typeof key === 'string' && key.length > 0),
+      );
+      const toUpdate: Array<[string, string]> = [];
+      map.forEach((cellKey, alias) => {
+        const moved = keyMoves[cellKey];
+        if (moved && moved !== cellKey) toUpdate.push([alias, moved]);
+      });
+      toUpdate.forEach(([alias, moved]) => {
+        map.set(alias, moved);
+        changed = true;
+      });
+      Object.entries(keyMoves).forEach(([oldKey, newKey]) => {
+        if (!oldKey || !newKey) return;
+        // A cell-key alias that is another thread's current key would steal it.
+        if (occupied.has(oldKey)) return;
+        if (map.get(oldKey) !== newKey) {
+          map.set(oldKey, newKey);
+          changed = true;
+        }
+      });
+    }
+    Object.values(commentsData).forEach((comment) => {
+      if (typeof comment?.key !== 'string' || !comment.key) {
+        return;
+      }
+      const aliases = commentAliases(comment);
+      if (aliases.length === 0) {
+        return;
+      }
+      if (skipUnmapped && existingSize > 0 && aliases.every((alias) => !map.has(alias))) {
+        return;
+      }
+      if (skipUnmapped) {
+        const existingKey = aliases
+          .map((alias) => map.get(alias))
+          .find((value): value is string => typeof value === 'string' && value.length > 0);
+        if (existingKey) {
+          aliases.forEach((alias) => {
+            if (!map.has(alias)) {
+              map.set(alias, existingKey);
+              changed = true;
+            }
+          });
+          return;
+        }
+      }
+      const commentKey = comment.key;
+      aliases.forEach((alias) => {
+        if (map.get(alias) !== commentKey) {
+          map.set(alias, commentKey);
+          changed = true;
+        }
+      });
+    });
+  });
+  if (changed) handleContentPortal?.();
+}

--- a/src/editor/utils/remap-comment-anchors.test.ts
+++ b/src/editor/utils/remap-comment-anchors.test.ts
@@ -1,0 +1,383 @@
+import { describe, expect, it } from 'vitest';
+import { commentKeyMovesById, remapCommentAnchors } from './remap-comment-anchors';
+import { applyCommentAnchorMap } from './comment-anchors-ydoc';
+import { buildBlockMoveIndexMap } from '../../sheet-engine/core/utils/comment-anchor-move';
+
+const thread = (key: string, id = key) => ({ id, key, content: key });
+
+describe('buildBlockMoveIndexMap', () => {
+  it('moves a single column right and shifts the gap left', () => {
+    // 4 cols, move col 0 to insert-at 2 after removal → [1,2,0,3]
+    expect(buildBlockMoveIndexMap(4, 0, 1, 2)).toEqual({
+      0: 2,
+      1: 0,
+      2: 1,
+      3: 3,
+    });
+  });
+
+  it('moves a block of columns left', () => {
+    // cols 2-3 moved to 0 → [2,3,0,1]
+    expect(buildBlockMoveIndexMap(4, 2, 2, 0)).toEqual({
+      0: 2,
+      1: 3,
+      2: 0,
+      3: 1,
+    });
+  });
+});
+
+describe('remapCommentAnchors', () => {
+  const sheetId = 'sheet-uuid';
+
+  it('remaps column keys after a column drag', () => {
+    const data = {
+      [`${sheetId}_0_0`]: thread(`${sheetId}_0_0`),
+      [`${sheetId}_0_2`]: thread(`${sheetId}_0_2`),
+      WITHOUT_CELL_1: thread('WITHOUT_CELL_1'),
+      'other_0_0': thread('other_0_0'),
+    };
+    const next = remapCommentAnchors(data, {
+      type: 'column',
+      sheetId,
+      sheetKeys: [sheetId],
+      indexMap: { 0: 2, 1: 0, 2: 1, 3: 3 },
+    });
+    expect(next[`${sheetId}_0_2`]?.content).toBe(`${sheetId}_0_0`);
+    expect(next[`${sheetId}_0_1`]?.content).toBe(`${sheetId}_0_2`);
+    expect(next.WITHOUT_CELL_1).toBe(data.WITHOUT_CELL_1);
+    expect(next.other_0_0).toBe(data.other_0_0);
+    expect(next[`${sheetId}_0_0`]).toBeUndefined();
+  });
+
+  it('remaps row keys after a row drag', () => {
+    const data = {
+      [`${sheetId}_1_3`]: thread(`${sheetId}_1_3`),
+    };
+    const next = remapCommentAnchors(data, {
+      type: 'row',
+      sheetId,
+      sheetKeys: [sheetId, '0'],
+      indexMap: { 0: 0, 1: 4, 2: 1, 3: 2, 4: 3 },
+    });
+    expect(next[`${sheetId}_4_3`]?.key).toBe(`${sheetId}_4_3`);
+    expect(next[`${sheetId}_1_3`]).toBeUndefined();
+  });
+
+  it('moves cell-range comments by the source→target offset', () => {
+    const data = {
+      [`${sheetId}_0_0`]: thread(`${sheetId}_0_0`, 'a'),
+      [`${sheetId}_5_5`]: thread(`${sheetId}_5_5`, 'keep'),
+    };
+    const next = remapCommentAnchors(data, {
+      type: 'cells',
+      sheetId,
+      sheetKeys: [sheetId],
+      source: { row: [0, 0], column: [0, 0] },
+      target: { row: [2, 2], column: [3, 3] },
+    });
+    expect(next[`${sheetId}_2_3`]?.id).toBe('a');
+    expect(next[`${sheetId}_0_0`]).toBeUndefined();
+    expect(next[`${sheetId}_5_5`]?.id).toBe('keep');
+  });
+
+  it('detaches destination-only comments so they do not collide', () => {
+    const data = {
+      [`${sheetId}_0_0`]: thread(`${sheetId}_0_0`, 'moving'),
+      [`${sheetId}_2_3`]: thread(`${sheetId}_2_3`, 'in-the-way'),
+    };
+    const next = remapCommentAnchors(data, {
+      type: 'cells',
+      sheetId,
+      sheetKeys: [sheetId],
+      source: { row: [0, 0], column: [0, 0] },
+      target: { row: [2, 2], column: [3, 3] },
+    });
+    expect(next[`${sheetId}_2_3`]?.id).toBe('moving');
+    expect(next['WITHOUT_CELL_in-the-way']?.id).toBe('in-the-way');
+  });
+
+  it('returns the same object when nothing moves', () => {
+    const data = { [`${sheetId}_0_0`]: thread(`${sheetId}_0_0`) };
+    const next = remapCommentAnchors(data, {
+      type: 'cells',
+      sheetId,
+      source: { row: [0, 0], column: [0, 0] },
+      target: { row: [0, 0], column: [0, 0] },
+    });
+    expect(next).toBe(data);
+  });
+
+  it('shifts comments at and after an insert-lefttop index', () => {
+    const data = {
+      [`${sheetId}_0_1`]: thread(`${sheetId}_0_1`, 'before'),
+      [`${sheetId}_0_2`]: thread(`${sheetId}_0_2`, 'at'),
+      [`${sheetId}_0_3`]: thread(`${sheetId}_0_3`, 'after'),
+      WITHOUT_CELL_1: thread('WITHOUT_CELL_1'),
+    };
+    const next = remapCommentAnchors(data, {
+      type: 'insert',
+      axis: 'column',
+      sheetId,
+      sheetKeys: [sheetId],
+      index: 2,
+      count: 1,
+      direction: 'lefttop',
+    });
+    expect(next[`${sheetId}_0_1`]?.id).toBe('before');
+    expect(next[`${sheetId}_0_3`]?.id).toBe('at');
+    expect(next[`${sheetId}_0_4`]?.id).toBe('after');
+    expect(next[`${sheetId}_0_2`]).toBeUndefined();
+    expect(next.WITHOUT_CELL_1).toBe(data.WITHOUT_CELL_1);
+  });
+
+  it('shifts only comments after an insert-rightbottom index', () => {
+    const data = {
+      [`${sheetId}_2_0`]: thread(`${sheetId}_2_0`, 'at'),
+      [`${sheetId}_3_0`]: thread(`${sheetId}_3_0`, 'after'),
+    };
+    const next = remapCommentAnchors(data, {
+      type: 'insert',
+      axis: 'row',
+      sheetId,
+      sheetKeys: [sheetId],
+      index: 2,
+      count: 2,
+      direction: 'rightbottom',
+    });
+    expect(next[`${sheetId}_2_0`]?.id).toBe('at');
+    expect(next[`${sheetId}_5_0`]?.id).toBe('after');
+    expect(next[`${sheetId}_3_0`]).toBeUndefined();
+  });
+
+  it('detaches comments on deleted rows and shifts later ones up', () => {
+    const data = {
+      [`${sheetId}_1_0`]: thread(`${sheetId}_1_0`, 'keep'),
+      [`${sheetId}_2_0`]: thread(`${sheetId}_2_0`, 'gone'),
+      [`${sheetId}_3_0`]: thread(`${sheetId}_3_0`, 'gone-too'),
+      [`${sheetId}_5_0`]: thread(`${sheetId}_5_0`, 'shift'),
+    };
+    const next = remapCommentAnchors(data, {
+      type: 'delete',
+      axis: 'row',
+      sheetId,
+      sheetKeys: [sheetId],
+      start: 2,
+      end: 3,
+    });
+    expect(next[`${sheetId}_1_0`]?.id).toBe('keep');
+    expect(next[`${sheetId}_3_0`]?.id).toBe('shift');
+    expect(next[`${sheetId}_2_0`]).toBeUndefined();
+    expect(next[`${sheetId}_5_0`]).toBeUndefined();
+    expect(next.WITHOUT_CELL_gone?.id).toBe('gone');
+    expect(next['WITHOUT_CELL_gone-too']?.id).toBe('gone-too');
+  });
+
+  it('detaches comments on deleted columns and shifts later ones left', () => {
+    const data = {
+      [`${sheetId}_0_0`]: thread(`${sheetId}_0_0`, 'keep'),
+      [`${sheetId}_0_1`]: thread(`${sheetId}_0_1`, 'gone'),
+      [`${sheetId}_0_4`]: thread(`${sheetId}_0_4`, 'shift'),
+    };
+    const next = remapCommentAnchors(data, {
+      type: 'delete',
+      axis: 'column',
+      sheetId,
+      sheetKeys: [sheetId],
+      start: 1,
+      end: 2,
+    });
+    expect(next[`${sheetId}_0_0`]?.id).toBe('keep');
+    expect(next[`${sheetId}_0_2`]?.id).toBe('shift');
+    expect(next[`${sheetId}_0_1`]).toBeUndefined();
+    expect(next.WITHOUT_CELL_gone?.id).toBe('gone');
+  });
+
+  it('builds old→new key moves by id in linear time', () => {
+    const before = {
+      [`${sheetId}_0_0`]: thread(`${sheetId}_0_0`, 'a'),
+      [`${sheetId}_0_1`]: thread(`${sheetId}_0_1`, 'b'),
+    };
+    const after = remapCommentAnchors(before, {
+      type: 'insert',
+      axis: 'column',
+      sheetId,
+      sheetKeys: [sheetId],
+      index: 0,
+      count: 1,
+      direction: 'lefttop',
+    });
+    expect(commentKeyMovesById(before, after)).toEqual({
+      [`${sheetId}_0_0`]: `${sheetId}_0_1`,
+      [`${sheetId}_0_1`]: `${sheetId}_0_2`,
+    });
+  });
+});
+
+describe('applyCommentAnchorMap', () => {
+  it('rekeys indexer comments by id so viewers follow published positions', () => {
+    const data = {
+      'sheet_0_0': thread('sheet_0_0', 'uuid-1'),
+      'sheet_1_1': thread('sheet_1_1', 'uuid-2'),
+    };
+    const next = applyCommentAnchorMap(data, {
+      'uuid-1': 'sheet_0_4',
+    });
+    expect(next.sheet_0_4?.id).toBe('uuid-1');
+    expect(next.sheet_0_4?.key).toBe('sheet_0_4');
+    expect(next.sheet_0_0).toBeUndefined();
+    expect(next.sheet_1_1?.id).toBe('uuid-2');
+  });
+
+  it('rekeys indexer comments by contentHash when local id and uuid differ', () => {
+    const data = {
+      sheet_0_0: {
+        ...thread('sheet_0_0', '0xviewer-uuid'),
+        contentHash: 'ipfs-hash-1',
+      },
+    };
+    const next = applyCommentAnchorMap(data, {
+      'comment-local-id': 'sheet_0_4',
+      'ipfs-hash-1': 'sheet_0_4',
+    });
+    expect(next.sheet_0_4?.id).toBe('0xviewer-uuid');
+    expect(next.sheet_0_0).toBeUndefined();
+  });
+
+  it('rekeys indexer comments by original cell key alias', () => {
+    const data = {
+      sheet_0_0: thread('sheet_0_0', '0xviewer-uuid'),
+    };
+    const next = applyCommentAnchorMap(data, {
+      'comment-local-id': 'sheet_0_4',
+      sheet_0_0: 'sheet_0_4',
+    });
+    expect(next.sheet_0_4?.id).toBe('0xviewer-uuid');
+    expect(next.sheet_0_0).toBeUndefined();
+  });
+
+  it('does not steal a thread when a stale cell-key alias matches its current cell', () => {
+    const data = {
+      sheet_3_4: { id: 'comment-iy', key: 'sheet_3_4', contentHash: 'hash-iy' },
+      sheet_3_6: { id: 'comment-v7', key: 'sheet_3_6', contentHash: 'hash-v7' },
+    };
+    const next = applyCommentAnchorMap(data, {
+      'comment-iy': 'sheet_3_4',
+      'hash-iy': 'sheet_3_4',
+      'comment-v7': 'sheet_3_6',
+      'hash-v7': 'sheet_3_6',
+      sheet_3_2: 'sheet_3_6',
+      sheet_3_5: 'sheet_3_4',
+      sheet_3_4: 'sheet_3_6',
+    });
+    expect(Object.keys(next)).toHaveLength(2);
+    expect(next.sheet_3_4?.id).toBe('comment-iy');
+    expect(next.sheet_3_6?.id).toBe('comment-v7');
+  });
+
+  it('keeps both threads when two comments would land on the same cell', () => {
+    const data = {
+      sheet_0_0: thread('sheet_0_0', 'a'),
+      sheet_0_1: thread('sheet_0_1', 'b'),
+    };
+    const next = applyCommentAnchorMap(data, {
+      a: 'sheet_0_9',
+      b: 'sheet_0_9',
+    });
+    expect(Object.keys(next)).toHaveLength(2);
+    expect(next.sheet_0_9?.id).toBe('a');
+    expect(next.WITHOUT_CELL_b?.id).toBe('b');
+  });
+});
+
+describe('comment anchors ydoc roundtrip', () => {
+  it('survives encode/apply so a published snapshot remaps viewer keys', async () => {
+    const Y = await import('yjs');
+    const {
+      writeCommentAnchorsToYdoc,
+      applyYdocCommentAnchors,
+    } = await import('./comment-anchors-ydoc');
+
+    const dsheetId = 'doc-1';
+    const ownerDoc = new Y.Doc();
+    writeCommentAnchorsToYdoc({
+      ydoc: ownerDoc,
+      dsheetId,
+      commentsData: {
+        'sheet_0_4': { id: 'uuid-1', key: 'sheet_0_4' },
+      },
+    });
+
+    const published = Y.encodeStateAsUpdate(ownerDoc);
+    const viewerDoc = new Y.Doc();
+    Y.applyUpdate(viewerDoc, published);
+
+    const indexerComments = {
+      'sheet_0_0': thread('sheet_0_0', 'uuid-1'),
+    };
+    const next = applyYdocCommentAnchors(indexerComments, viewerDoc, dsheetId);
+    expect(next.sheet_0_4?.id).toBe('uuid-1');
+    expect(next.sheet_0_0).toBeUndefined();
+  });
+
+  it('does not write an occupied cell-key as an alias for another thread', async () => {
+    const Y = await import('yjs');
+    const { writeCommentAnchorsToYdoc, readCommentAnchorsFromYdoc } = await import(
+      './comment-anchors-ydoc'
+    );
+
+    const dsheetId = 'doc-1';
+    const doc = new Y.Doc();
+    writeCommentAnchorsToYdoc({
+      ydoc: doc,
+      dsheetId,
+      commentsData: {
+        sheet_0_4: { id: 'comment-iy', key: 'sheet_0_4' },
+        sheet_0_6: { id: 'comment-v7', key: 'sheet_0_6' },
+      },
+      keyMoves: {
+        sheet_0_5: 'sheet_0_4',
+        sheet_0_4: 'sheet_0_6',
+      },
+    });
+
+    const anchors = readCommentAnchorsFromYdoc(doc, dsheetId);
+    expect(anchors['comment-iy']).toBe('sheet_0_4');
+    expect(anchors['comment-v7']).toBe('sheet_0_6');
+    expect(anchors.sheet_0_5).toBe('sheet_0_4');
+    expect(anchors.sheet_0_4).toBeUndefined();
+  });
+
+  it('skipUnmapped backfills hashes without moving remapped positions', async () => {
+    const Y = await import('yjs');
+    const { writeCommentAnchorsToYdoc, readCommentAnchorsFromYdoc } = await import(
+      './comment-anchors-ydoc'
+    );
+
+    const dsheetId = 'doc-1';
+    const doc = new Y.Doc();
+    writeCommentAnchorsToYdoc({
+      ydoc: doc,
+      dsheetId,
+      commentsData: {
+        sheet_0_4: { id: 'comment-iy', key: 'sheet_0_4', contentHash: 'hash-iy' },
+        sheet_0_6: { id: 'comment-v7', key: 'sheet_0_6', contentHash: 'hash-v7' },
+      },
+    });
+    writeCommentAnchorsToYdoc({
+      ydoc: doc,
+      dsheetId,
+      commentsData: {
+        sheet_0_7: { id: 'comment-iy', key: 'sheet_0_7', contentHash: 'hash-iy' },
+        sheet_0_5: { id: 'comment-v7', key: 'sheet_0_5', contentHash: 'hash-v7' },
+      },
+      skipUnmapped: true,
+    });
+
+    const anchors = readCommentAnchorsFromYdoc(doc, dsheetId);
+    expect(anchors['comment-iy']).toBe('sheet_0_4');
+    expect(anchors['comment-v7']).toBe('sheet_0_6');
+    expect(anchors['hash-iy']).toBe('sheet_0_4');
+    expect(anchors['hash-v7']).toBe('sheet_0_6');
+  });
+});

--- a/src/editor/utils/remap-comment-anchors.ts
+++ b/src/editor/utils/remap-comment-anchors.ts
@@ -1,0 +1,177 @@
+import type { CommentAnchorMove } from '../../sheet-engine/core/settings';
+import { parseCellKey } from './comment-key-utils';
+
+const matchesSheet = (
+  parsedSheetId: string | undefined,
+  move: CommentAnchorMove,
+): boolean => {
+  if (parsedSheetId == null) return false;
+  if (move.sheetKeys?.length) {
+    return move.sheetKeys.includes(parsedSheetId);
+  }
+  return parsedSheetId === move.sheetId;
+};
+
+const inRange = (
+  row: number,
+  col: number,
+  range: { row: [number, number]; column: [number, number] },
+): boolean =>
+  row >= range.row[0] &&
+  row <= range.row[1] &&
+  col >= range.column[0] &&
+  col <= range.column[1];
+
+const cellKey = (sheetId: string, row: number, col: number) =>
+  `${sheetId}_${row}_${col}`;
+
+const withKey = <T extends { key?: string }>(comment: T, newKey: string): T =>
+  newKey === comment.key ? comment : { ...comment, key: newKey };
+
+/**
+ * old cell-key → new cell-key, matched by comment id. Used when writing
+ * ydoc aliases so indexer keys still resolve after a remap.
+ */
+export function commentKeyMovesById<T extends { id?: string; key?: string }>(
+  before: Record<string, T>,
+  after: Record<string, T>,
+): Record<string, string> {
+  const nextById = new Map<string, string>();
+  for (const comment of Object.values(after)) {
+    if (comment?.id && comment.key) nextById.set(comment.id, comment.key);
+  }
+  const keyMoves: Record<string, string> = {};
+  for (const [oldKey, comment] of Object.entries(before)) {
+    if (!comment?.id) continue;
+    const newKey = nextById.get(comment.id);
+    if (newKey && newKey !== oldKey) keyMoves[oldKey] = newKey;
+  }
+  return keyMoves;
+}
+
+type NextCoord = (
+  row: number,
+  col: number,
+) => { row: number; col: number } | 'detach';
+
+function remapByPosition<T extends { key?: string; id?: string }>(
+  commentsData: Record<string, T>,
+  move: CommentAnchorMove,
+  nextCoord: NextCoord,
+  detachPrefix: string,
+): Record<string, T> {
+  const next: Record<string, T> = {};
+  let changed = false;
+  const displaced: T[] = [];
+  for (const [key, comment] of Object.entries(commentsData)) {
+    const parsed = parseCellKey(key);
+    if (!parsed || !matchesSheet(parsed.sheetId, move)) {
+      next[key] = comment;
+      continue;
+    }
+    const mapped = nextCoord(parsed.row, parsed.col);
+    if (mapped === 'detach') {
+      changed = true;
+      displaced.push(comment);
+      continue;
+    }
+    const newKey = cellKey(
+      parsed.sheetId ?? move.sheetId,
+      mapped.row,
+      mapped.col,
+    );
+    if (newKey !== key) changed = true;
+    next[newKey] = withKey(comment, newKey);
+  }
+  displaced.forEach((comment, i) => {
+    const withoutKey = `WITHOUT_CELL_${comment.id || `${detachPrefix}_${i}`}`;
+    next[withoutKey] = { ...comment, key: withoutKey };
+  });
+  return changed ? next : commentsData;
+}
+
+/**
+ * Remap in-memory comment keys after a row/column drag, cell-range move,
+ * or insert/delete of rows/columns.
+ *
+ * - Row/column drag: apply the full permutation `indexMap` (no collisions).
+ * - Cells: comments in the source rectangle follow the offset; comments that
+ *   only lived in the destination are detached to `WITHOUT_CELL_<id>` so they
+ *   remain in the sidebar instead of colliding with the incoming thread.
+ * - Insert: comments at/after the insertion point shift by `count`.
+ * - Delete: comments on removed rows/cols are detached; later ones shift up/left.
+ */
+export function remapCommentAnchors<T extends { key?: string; id?: string }>(
+  commentsData: Record<string, T>,
+  move: CommentAnchorMove,
+): Record<string, T> {
+  if (Object.keys(commentsData).length === 0) return commentsData;
+
+  if (move.type === 'insert') {
+    if (move.count <= 0) return commentsData;
+    const shiftStart =
+      move.direction === 'lefttop' ? move.index : move.index + 1;
+    return remapByPosition(
+      commentsData,
+      move,
+      (row, col) => ({
+        row:
+          move.axis === 'row' && row >= shiftStart ? row + move.count : row,
+        col:
+          move.axis === 'column' && col >= shiftStart
+            ? col + move.count
+            : col,
+      }),
+      'deleted',
+    );
+  }
+
+  if (move.type === 'delete') {
+    const slen = move.end - move.start + 1;
+    if (slen <= 0) return commentsData;
+    return remapByPosition(
+      commentsData,
+      move,
+      (row, col) => {
+        const idx = move.axis === 'row' ? row : col;
+        if (idx >= move.start && idx <= move.end) return 'detach';
+        return {
+          row: move.axis === 'row' && row > move.end ? row - slen : row,
+          col: move.axis === 'column' && col > move.end ? col - slen : col,
+        };
+      },
+      'deleted',
+    );
+  }
+
+  if (move.type !== 'cells') {
+    return remapByPosition(
+      commentsData,
+      move,
+      (row, col) => ({
+        row: move.type === 'row' ? (move.indexMap[row] ?? row) : row,
+        col: move.type === 'column' ? (move.indexMap[col] ?? col) : col,
+      }),
+      'deleted',
+    );
+  }
+
+  const rowOffset = move.target.row[0] - move.source.row[0];
+  const colOffset = move.target.column[0] - move.source.column[0];
+  if (rowOffset === 0 && colOffset === 0) return commentsData;
+
+  return remapByPosition(
+    commentsData,
+    move,
+    (row, col) => {
+      if (inRange(row, col, move.source)) {
+        return { row: row + rowOffset, col: col + colOffset };
+      }
+      if (inRange(row, col, move.target)) return 'detach';
+      return { row, col };
+    },
+    'displaced',
+  );
+}
+
+export type { CommentAnchorMove };

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,8 +16,10 @@ export type {
   CommentReply,
   CommentActionParams,
   CommentsConfig,
+  CommentAnchorMove,
 } from './editor/types/comments';
 export { CommentAction } from './editor/types/comments';
+export { remapCommentAnchors } from './editor/utils/remap-comment-anchors';
 export { CommentsContent } from './editor/components/comments/comment-sidebar';
 export { CommentCellUI } from './editor/components/comments/comment-cell-popup';
 export { useEnsStatus } from './editor/components/comments/ens/use-ens-status';

--- a/src/sheet-engine/core/index.ts
+++ b/src/sheet-engine/core/index.ts
@@ -18,7 +18,12 @@ export type { Context } from './context';
 
 // settings
 export { defaultSettings } from './settings';
-export type { Settings, Hooks, DateBaseLocale } from './settings';
+export type {
+  Settings,
+  Hooks,
+  DateBaseLocale,
+  CommentAnchorMove,
+} from './settings';
 
 // events
 export {

--- a/src/sheet-engine/core/modules/moveCells.ts
+++ b/src/sheet-engine/core/modules/moveCells.ts
@@ -21,6 +21,10 @@ import { jfrefreshgrid } from './refresh';
 import { CFSplitRange } from './ConditionFormat';
 import { functionMoveReference } from './formula';
 import { moveCellFormatRanges, rangesEqual } from '../utils/range-format';
+import {
+  getSheetCommentKeyPrefixes,
+  notifyCommentAnchorMove,
+} from '../utils/comment-anchor-move';
 
 const dragCellThreshold = 8;
 
@@ -764,6 +768,20 @@ export function onCellsMoveEnd(
   // };
 
   jfrefreshgrid(ctx, d, range);
+
+  notifyCommentAnchorMove(ctx, {
+    type: 'cells',
+    sheetId: String(file?.id ?? ctx.currentSheetId),
+    sheetKeys: getSheetCommentKeyPrefixes(file, index),
+    source: {
+      row: [range[0].row[0], range[0].row[1]],
+      column: [range[0].column[0], range[0].column[1]],
+    },
+    target: {
+      row: [range[1].row[0], range[1].row[1]],
+      column: [range[1].column[0], range[1].column[1]],
+    },
+  });
 
   // selectHightlightShow();
 

--- a/src/sheet-engine/core/modules/rowcol.ts
+++ b/src/sheet-engine/core/modules/rowcol.ts
@@ -25,6 +25,10 @@ import {
   getInsertRowColSnapshotBounds,
   snapshotPersistedCelldataInRange,
 } from '../utils/ydoc-celldata-changes';
+import {
+  getSheetCommentKeyPrefixes,
+  notifyCommentAnchorMove,
+} from '../utils/comment-anchor-move';
 
 const refreshLocalMergeData = (merge_new: Record<string, any>, file: Sheet) => {
   Object.entries(merge_new).forEach(([, v]) => {
@@ -1639,6 +1643,16 @@ export function insertRowCol(
     );
   }
 
+  notifyCommentAnchorMove(ctx, {
+    type: 'insert',
+    axis: type,
+    sheetId: String(file.id ?? id),
+    sheetKeys: getSheetCommentKeyPrefixes(file, curOrder),
+    index,
+    count,
+    direction,
+  });
+
   // if (type === "row") {
   //   const scrollLeft = $("#luckysheet-cell-main").scrollLeft();
   //   const scrollTop = $("#luckysheet-cell-main").scrollTop();
@@ -2695,6 +2709,15 @@ export function deleteRowCol(
     d.length,
     d[0]?.length ?? 0,
   );
+
+  notifyCommentAnchorMove(ctx, {
+    type: 'delete',
+    axis: type,
+    sheetId: String(file.id ?? id),
+    sheetKeys: getSheetCommentKeyPrefixes(file, curOrder),
+    start,
+    end,
+  });
 
   if (file.id === ctx.currentSheetId) {
     ctx.config = cfg;

--- a/src/sheet-engine/core/settings.ts
+++ b/src/sheet-engine/core/settings.ts
@@ -158,7 +158,46 @@ export type Hooks = {
   afterShowGridLinesChange?: () => void;
   afterNameChanges?: () => void;
   afterStatusChanges?: () => void;
+  /**
+   * Fired after row/column drag-drop, cell-range move, or insert/delete
+   * so host apps can remap comment keys (`${sheetId}_${row}_${col}`).
+   */
+  afterCommentAnchorMove?: (move: CommentAnchorMove) => void;
 };
+
+export type CommentAnchorMove =
+  | {
+      type: 'row' | 'column';
+      sheetId: string;
+      /** Prefixes that identify this sheet in comment keys (id, order, index). */
+      sheetKeys?: string[];
+      /** old index → new index for every row/col on the sheet */
+      indexMap: Record<number, number>;
+    }
+  | {
+      type: 'cells';
+      sheetId: string;
+      sheetKeys?: string[];
+      source: { row: [number, number]; column: [number, number] };
+      target: { row: [number, number]; column: [number, number] };
+    }
+  | {
+      type: 'insert';
+      axis: 'row' | 'column';
+      sheetId: string;
+      sheetKeys?: string[];
+      index: number;
+      count: number;
+      direction: 'lefttop' | 'rightbottom';
+    }
+  | {
+      type: 'delete';
+      axis: 'row' | 'column';
+      sheetId: string;
+      sheetKeys?: string[];
+      start: number;
+      end: number;
+    };
 
 type CommentUIDragFn = (
   e: React.MouseEvent<HTMLDivElement, MouseEvent>,

--- a/src/sheet-engine/core/utils/cell-persist-utils.ts
+++ b/src/sheet-engine/core/utils/cell-persist-utils.ts
@@ -34,8 +34,9 @@ export function hasCellMeaningfulContent(
   // keep merge hit-testing. config.merge alone is not enough for canvas.
   if (cell.mc != null) return true;
   if (cell.hl != null) return true;
-  // Comment/note-only cells (no value) must still persist.
-  if (cell.ps != null) return true;
+  // Do not persist `ps`. Fileverse comments live in the host store and are
+  // remapped by cell key; treating marker-only cells as data is what made
+  // viewers diverge from the owner after row/column drag.
   if (typeof cell.m === "string" && cell.m.length > 0) return true;
 
   const inline = cell.ct?.s;

--- a/src/sheet-engine/core/utils/comment-anchor-move.ts
+++ b/src/sheet-engine/core/utils/comment-anchor-move.ts
@@ -1,0 +1,59 @@
+import type { CommentAnchorMove } from '../settings';
+
+/**
+ * Build oldIndex → newIndex for a contiguous block move (row or column drag).
+ * `targetIndex` is the insertion index *after* the block has been removed,
+ * matching the splice used on the sheet data.
+ */
+export function buildBlockMoveIndexMap(
+  length: number,
+  sourceStart: number,
+  moveCount: number,
+  targetIndex: number,
+): Record<number, number> {
+  if (length <= 0 || moveCount <= 0) return {};
+  const order = Array.from({ length }, (_, i) => i);
+  const moved = order.splice(sourceStart, moveCount);
+  let insertAt = targetIndex;
+  if (insertAt < 0) insertAt = 0;
+  if (insertAt > order.length) insertAt = order.length;
+  order.splice(insertAt, 0, ...moved);
+  const map: Record<number, number> = {};
+  order.forEach((oldIdx, newIdx) => {
+    map[oldIdx] = newIdx;
+  });
+  return map;
+}
+
+export function getSheetCommentKeyPrefixes(
+  sheet: { id?: string; order?: number } | null | undefined,
+  sheetIndex: number,
+): string[] {
+  const keys = new Set<string>();
+  if (sheet?.id != null && String(sheet.id).length > 0) {
+    keys.add(String(sheet.id));
+  }
+  if (typeof sheet?.order === 'number') {
+    keys.add(String(sheet.order));
+  }
+  if (Number.isFinite(sheetIndex)) {
+    keys.add(String(sheetIndex));
+  }
+  return [...keys];
+}
+
+export function notifyCommentAnchorMove(
+  ctx: { hooks?: { afterCommentAnchorMove?: (move: CommentAnchorMove) => void } },
+  move: CommentAnchorMove,
+): void {
+  const fn = ctx.hooks?.afterCommentAnchorMove;
+  if (!fn) return;
+  // Must run in the same turn as the row/column splice. A microtask lets
+  // ydoc cell persist encode *before* remapped anchors are written, so
+  // viewers load new cells with stale comment positions.
+  try {
+    fn(move);
+  } catch (err) {
+    console.error('[comments] afterCommentAnchorMove failed', err);
+  }
+}

--- a/src/sheet-engine/react/components/SheetOverlay/drag_and_drop/column-helpers.tsx
+++ b/src/sheet-engine/react/components/SheetOverlay/drag_and_drop/column-helpers.tsx
@@ -23,6 +23,11 @@ import {
   remapCellFormatRanges,
 } from '../../../../core/utils/range-format';
 import { remapBorderInfo } from '../../../../core/utils/border-config-utils';
+import {
+  buildBlockMoveIndexMap,
+  getSheetCommentKeyPrefixes,
+  notifyCommentAnchorMove,
+} from '../../../../core/utils/comment-anchor-move';
 
 export function numberToColumnName(num: number): string {
   return indexToColumnChar(num);
@@ -431,7 +436,6 @@ export const useColumnDragAndDrop = (
             Math.max(0, numRowsBeforeMove - 1),
             affectedColStart,
             affectedColEnd,
-            _sheet.celldata,
           );
 
           // Move selected column block in each row, preserving relative order.
@@ -447,23 +451,12 @@ export const useColumnDragAndDrop = (
 
           // update formula
           const d = getFlowdata(draft);
-          const colMap: Record<number, number> = (() => {
-            const totalCols = rows[0]?.length ?? 0;
-            const order = Array.from({ length: totalCols }, (_, i) => i);
-            const sourceStart = selectedStart;
-            const count = moveCount;
-            if (count <= 0) return {};
-            const moved = order.splice(sourceStart, count);
-            let insertAt = targetIndex;
-            if (insertAt < 0) insertAt = 0;
-            if (insertAt > order.length) insertAt = order.length;
-            order.splice(insertAt, 0, ...moved);
-            const map: Record<number, number> = {};
-            order.forEach((oldIdx, newIdx) => {
-              map[oldIdx] = newIdx;
-            });
-            return map;
-          })();
+          const colMap = buildBlockMoveIndexMap(
+            rows[0]?.length ?? 0,
+            selectedStart,
+            moveCount,
+            targetIndex,
+          );
 
           const previousFormatRanges = _sheet.config?.cellFormatRanges;
           const nextFormatRanges = remapCellFormatRanges(
@@ -759,8 +752,9 @@ export const useColumnDragAndDrop = (
             }
           }
 
-          // Comments are stored on cell.ps and move with row/column data.
-          // Reset visible comment overlays so positions are recomputed lazily.
+          // Host-owned comment keys (`${sheetId}_${row}_${col}`) do not move
+          // with the splice. Notify after celldata is written to ydoc so the
+          // portal persist is not a half-update (old cells + new anchors).
           draft.commentBoxes = [];
           draft.hoveredCommentBox = undefined;
           draft.editingCommentBox = undefined;
@@ -830,6 +824,12 @@ export const useColumnDragAndDrop = (
             affectedColEnd,
             ydocBeforePersisted,
           );
+          notifyCommentAnchorMove(draft, {
+            type: 'column',
+            sheetId: String(_sheet.id ?? draft.currentSheetId),
+            sheetKeys: getSheetCommentKeyPrefixes(_sheet, sheetIdx),
+            indexMap: colMap,
+          });
           const rowLen = d?.length || 0;
           const rowEnd = Math.max(0, rowLen - 1);
           api.setSelection(

--- a/src/sheet-engine/react/components/SheetOverlay/drag_and_drop/row-helpers.tsx
+++ b/src/sheet-engine/react/components/SheetOverlay/drag_and_drop/row-helpers.tsx
@@ -22,6 +22,11 @@ import {
   remapCellFormatRanges,
 } from '../../../../core/utils/range-format';
 import { remapBorderInfo } from '../../../../core/utils/border-config-utils';
+import {
+  buildBlockMoveIndexMap,
+  getSheetCommentKeyPrefixes,
+  notifyCommentAnchorMove,
+} from '../../../../core/utils/comment-anchor-move';
 
 export const useRowDragAndDrop = (
   containerRef: RefObject<HTMLDivElement | null>,
@@ -422,7 +427,6 @@ export const useRowDragAndDrop = (
             affectedRowEnd,
             0,
             Math.max(0, numColsBeforeMove - 1),
-            _sheet.celldata,
           );
 
           // Move selected row block in one splice pair, preserving relative order.
@@ -433,22 +437,12 @@ export const useRowDragAndDrop = (
           updateContextWithSheetData(draft, _sheet.data);
 
           const d = getFlowdata(draft);
-          const rowMap: Record<number, number> = (() => {
-            const order = Array.from({ length: rows.length }, (_, i) => i);
-            const sourceStart = selectedStart;
-            const count = moveCount;
-            if (count <= 0) return {};
-            const moved = order.splice(sourceStart, count);
-            let insertAt = targetIndex;
-            if (insertAt < 0) insertAt = 0;
-            if (insertAt > order.length) insertAt = order.length;
-            order.splice(insertAt, 0, ...moved);
-            const map: Record<number, number> = {};
-            order.forEach((oldIdx, newIdx) => {
-              map[oldIdx] = newIdx;
-            });
-            return map;
-          })();
+          const rowMap = buildBlockMoveIndexMap(
+            rows.length,
+            selectedStart,
+            moveCount,
+            targetIndex,
+          );
 
           const previousFormatRanges = _sheet.config?.cellFormatRanges;
           const nextFormatRanges = remapCellFormatRanges(
@@ -743,8 +737,9 @@ export const useRowDragAndDrop = (
             }
           }
 
-          // Comments are stored on cell.ps and move with row/column data.
-          // Reset visible comment overlays so positions are recomputed lazily.
+          // Host-owned comment keys (`${sheetId}_${row}_${col}`) do not move
+          // with the splice. Notify after celldata is written to ydoc so the
+          // portal persist is not a half-update (old cells + new anchors).
           draft.commentBoxes = [];
           draft.hoveredCommentBox = undefined;
           draft.editingCommentBox = undefined;
@@ -811,6 +806,12 @@ export const useRowDragAndDrop = (
             Math.max(0, (rows[0]?.length ?? 1) - 1),
             ydocBeforePersisted,
           );
+          notifyCommentAnchorMove(draft, {
+            type: 'row',
+            sheetId: String(_sheet.id ?? draft.currentSheetId),
+            sheetKeys: getSheetCommentKeyPrefixes(_sheet, sheetIdx),
+            indexMap: rowMap,
+          });
           const colLen = d?.[0]?.length || 0;
           const colEnd = Math.max(0, colLen - 1);
           api.setSelection(


### PR DESCRIPTION
Persist remapped comment anchors with celldata in the same snapshot so viewers do not keep markers on old cells.