### PR TITLE
refactor(storage): make the commit-storage boundary storage-agnostic

### DIFF
--- a/src/editor/components/smart-contract/use-smart-contract-modal.ts
+++ b/src/editor/components/smart-contract/use-smart-contract-modal.ts
@@ -18,14 +18,14 @@ export function useSmartContractModal({
     address: Hex,
     chain: SupportedChain,
     abi: string,
-    smartContractName: string
+    smartContractName: string,
   ) => Promise<void>;
   setShowSmartContractModal: (show: boolean) => void;
   registryMapRef: React.MutableRefObject<Record<string, ContractConfig>>;
 }) {
   const [inputAddress, setInputAddress] = useState<string>('');
   const [selectedChain, setSelectedChain] = useState<SupportedChain>(
-    SupportedChain.Ethereum
+    SupportedChain.Ethereum,
   );
   const [formStep, setFormStep] = useState<number>(1);
   const [abiCode, setAbiCode] = useState('');
@@ -78,7 +78,6 @@ export function useSmartContractModal({
         size: formatFileSize(file.size),
       });
       setUploadProgress(50);
-      // handle file upload to ipfs
       const content = await readFileContent(file);
       validateAbi(content);
       setUploadProgress(100);
@@ -147,7 +146,7 @@ export function useSmartContractModal({
       inputAddress as Hex,
       selectedChain,
       _abi,
-      smartContractName
+      smartContractName,
     );
     onClose();
   };

--- a/src/editor/types/smart-contract.ts
+++ b/src/editor/types/smart-contract.ts
@@ -43,7 +43,7 @@ export interface SmartContractConfig {
   contracts?: ContractConfig[];
   /** RPC URL per chain. Falls back to bundled defaults when omitted. */
   rpcConfig?: Partial<Record<SupportedChain, string>>;
-  /** Resolve ABI from stored reference (e.g. IPFS hash). Required for user-saved contracts with abiHash. */
+  /** Resolve ABI from stored reference (e.g. an IPFS CID or a Swarm reference — opaque to the package). Required for user-saved contracts with abiHash. */
   resolveAbi?: (abiHash: string) => Promise<Abi>;
   /** Persist a new contract. When omitted, package keeps it in session memory only. */
   onAddContract?: (input: NewContractInput) => Promise<void>;
@@ -67,7 +67,8 @@ export interface CallerParams {
 export interface FetchAbiParams {
   contractAddress: Hex;
   chain: import('viem').Chain;
-  ipfsHash?: string;
+  /** Stored ABI reference (`ContractConfig.abiHash`), resolved via `resolveAbi`. */
+  abiRef?: string;
 }
 
 export type ParsedFunction = {

--- a/src/editor/utils/smart-contract/reading-utils.test.ts
+++ b/src/editor/utils/smart-contract/reading-utils.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest';
+import { mainnet } from 'viem/chains';
+import type { Abi, Hex } from 'viem';
+
+import { fetchAbi, type SmartContractRuntimeDeps } from './reading-utils';
+
+const CONTRACT: Hex = '0x0000000000000000000000000000000000000001';
+const ABI: Abi = [
+  {
+    type: 'function',
+    name: 'answer',
+    inputs: [],
+    outputs: [{ type: 'uint256' }],
+    stateMutability: 'view',
+  },
+];
+
+/**
+ * The ABI reference is storage-agnostic: `fetchAbi` never interprets it, it
+ * only hands it to the host's `resolveAbi`. These tests pin that boundary so
+ * a backend swap (IPFS → Swarm → anything) stays a host-side concern.
+ */
+describe('fetchAbi', () => {
+  it('resolves a stored ABI through resolveAbi, passing the reference verbatim', async () => {
+    const resolveAbi = vi.fn().mockResolvedValue(ABI);
+    const deps: SmartContractRuntimeDeps = { resolveAbi, abiCache: {} };
+
+    const abiRef = 'any-opaque-reference:swarm-or-ipfs-or-else';
+    const abi = await fetchAbi(
+      { contractAddress: CONTRACT, chain: mainnet, abiRef },
+      deps,
+    );
+
+    expect(abi).toBe(ABI);
+    expect(resolveAbi).toHaveBeenCalledWith(abiRef);
+  });
+
+  it('caches per contract/chain/reference and skips a second resolve', async () => {
+    const resolveAbi = vi.fn().mockResolvedValue(ABI);
+    const deps: SmartContractRuntimeDeps = { resolveAbi, abiCache: {} };
+    const params = {
+      contractAddress: CONTRACT,
+      chain: mainnet,
+      abiRef: 'ref-1',
+    };
+
+    await fetchAbi(params, deps);
+    await fetchAbi(params, deps);
+
+    expect(resolveAbi).toHaveBeenCalledTimes(1);
+    expect(deps.abiCache[`${CONTRACT}_${mainnet.id}_ref-1`]).toBe(ABI);
+  });
+
+  it('resolves again for a different reference to the same contract', async () => {
+    const resolveAbi = vi.fn().mockResolvedValue(ABI);
+    const deps: SmartContractRuntimeDeps = { resolveAbi, abiCache: {} };
+
+    await fetchAbi(
+      { contractAddress: CONTRACT, chain: mainnet, abiRef: 'ref-1' },
+      deps,
+    );
+    await fetchAbi(
+      { contractAddress: CONTRACT, chain: mainnet, abiRef: 'ref-2' },
+      deps,
+    );
+
+    expect(resolveAbi).toHaveBeenCalledTimes(2);
+    expect(resolveAbi).toHaveBeenNthCalledWith(2, 'ref-2');
+  });
+});

--- a/src/editor/utils/smart-contract/reading-utils.ts
+++ b/src/editor/utils/smart-contract/reading-utils.ts
@@ -73,8 +73,8 @@ export const fetchAbi = async (
   params: FetchAbiParams,
   deps: SmartContractRuntimeDeps,
 ): Promise<Abi> => {
-  const cacheKey = params.ipfsHash
-    ? `${params.contractAddress}_${params.chain.id}_${params.ipfsHash}`
+  const cacheKey = params.abiRef
+    ? `${params.contractAddress}_${params.chain.id}_${params.abiRef}`
     : `${params.contractAddress}_${params.chain.id}`;
 
   if (deps.abiCache[cacheKey]) {
@@ -83,8 +83,8 @@ export const fetchAbi = async (
 
   let abi: Abi | undefined;
 
-  if (params.ipfsHash && deps.resolveAbi) {
-    abi = await deps.resolveAbi(params.ipfsHash);
+  if (params.abiRef && deps.resolveAbi) {
+    abi = await deps.resolveAbi(params.abiRef);
   } else {
     abi = await fetchVerifiedAbi(params.contractAddress, params.chain);
   }
@@ -194,7 +194,13 @@ export const getCallerParamsByAddress = async (
   const abi = await fetchAbi({ contractAddress, chain }, deps);
   const [functionName, ...args] = rest;
 
-  return { abi, contractAddress, chain, functionName: functionName as string, args };
+  return {
+    abi,
+    contractAddress,
+    chain,
+    functionName: functionName as string,
+    args,
+  };
 };
 
 export const getCallerParamsByName = async (
@@ -214,7 +220,7 @@ export const getCallerParamsByName = async (
     {
       contractAddress: contractConfig.address,
       chain,
-      ipfsHash: contractConfig.abiHash || undefined,
+      abiRef: contractConfig.abiHash || undefined,
     },
     deps,
   );
@@ -425,7 +431,7 @@ export const fetchContractAbi = (
     {
       contractAddress: contract.address,
       chain,
-      ipfsHash: contract.abiHash || undefined,
+      abiRef: contract.abiHash || undefined,
     },
     deps,
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,12 @@ export { FLVURL } from '@fileverse-dev/formulajs';
 export { loadLocale } from '@sheet-engine/core';
 
 // Types
-export type { ErrorMessageHandlerReturnType, DataBlockEvent, DataBlockEventType, ApiKeyStorage } from './editor/types';
+export type {
+  ErrorMessageHandlerReturnType,
+  DataBlockEvent,
+  DataBlockEventType,
+  ApiKeyStorage,
+} from './editor/types';
 export type { PanelConfig, PanelId, BuiltInPanelType } from './editor/types';
 export type {
   CommentThread,
@@ -37,6 +42,8 @@ export type {
   CollabConnectionConfig,
   CollabSessionMeta,
   CollabServices,
+  CommitToStorageFn,
+  FetchFromStorageFn,
   CollabCallbacks,
   CollabState,
   CollabStatus,

--- a/src/sync-local/SyncManager.ts
+++ b/src/sync-local/SyncManager.ts
@@ -50,13 +50,13 @@ export class SyncManager {
   private readonly MAX_QUEUE_SIZE = 5;
   private _awarenessUpdateHandler:
     | ((
-      changes: {
-        added: number[];
-        updated: number[];
-        removed: number[];
-      },
-      origin: any,
-    ) => void)
+        changes: {
+          added: number[];
+          updated: number[];
+          removed: number[];
+        },
+        origin: any,
+      ) => void)
     | null = null;
 
   // --- Config (from constructor) ---
@@ -605,7 +605,7 @@ export class SyncManager {
       const updates: Uint8Array[] = [];
       // Tracks a failed commit-content fetch/decrypt — a transient storage
       // problem, not proof the room is poisoned. Gates the poisoned-room
-      // check below so a bad IPFS fetch isn't misreported as "ask the owner
+      // check below so a bad storage fetch isn't misreported as "ask the owner
       // to reopen the sheet" when a retry would likely just work.
       let commitContentFetchFailed = false;
 
@@ -763,15 +763,17 @@ export class SyncManager {
           Y.encodeStateAsUpdate(this.ydoc),
         );
         const file = objectToFile({ data: localContent }, 'commit');
-        const ipfsHash = await this.servicesRef.commitToStorage(file);
+        const contentRef = await this.servicesRef.commitToStorage(file);
 
-        if (!ipfsHash) {
-          throw new Error('Failed to upload commit to IPFS: no hash returned');
+        if (!contentRef) {
+          throw new Error(
+            'Failed to upload commit to storage: no content reference returned',
+          );
         }
 
         const commitResponse = await this.socketClient?.commitUpdates({
           updates: ids,
-          cid: ipfsHash,
+          cid: contentRef,
         });
 
         if (!commitResponse?.status) {
@@ -936,15 +938,17 @@ export class SyncManager {
           ),
         };
         const file = objectToFile(commitContent, 'commit');
-        const ipfsHash = await this.servicesRef!.commitToStorage(file);
+        const contentRef = await this.servicesRef!.commitToStorage(file);
 
-        if (!ipfsHash) {
-          throw new Error('Failed to upload commit to IPFS: no hash returned');
+        if (!contentRef) {
+          throw new Error(
+            'Failed to upload commit to storage: no content reference returned',
+          );
         }
 
         const response = await this.socketClient?.commitUpdates({
           updates,
-          cid: ipfsHash,
+          cid: contentRef,
         });
 
         if (!response?.status) {

--- a/src/sync-local/types/index.ts
+++ b/src/sync-local/types/index.ts
@@ -34,10 +34,29 @@ export interface CollabSessionMeta {
   isEns?: boolean;
 }
 
-/** Storage integrations the sync engine depends on */
+/**
+ * Store an encrypted commit file on the host's storage backend (IPFS,
+ * Swarm, ...) and return its content reference. The sync engine treats the
+ * returned reference as opaque (an IPFS CID, a Swarm reference, ...): it is
+ * handed to the sync server as the commit pointer and later passed back
+ * verbatim to `fetchFromStorage`.
+ */
+export type CommitToStorageFn = (file: File) => Promise<string>;
+
+/**
+ * Fetch a commit's content by the reference `commitToStorage` returned for
+ * it. The resolved value must expose the stored commit under `data`.
+ */
+export type FetchFromStorageFn = (contentRef: string) => Promise<any>;
+
+/**
+ * Storage integrations the sync engine depends on. Storage-agnostic: the
+ * host decides where commit files live (IPFS, Swarm, ...); the engine only
+ * round-trips the opaque content reference between these two functions.
+ */
 export interface CollabServices {
-  commitToStorage?: (file: File) => Promise<string>;
-  fetchFromStorage?: (cid: string) => Promise<any>;
+  commitToStorage?: CommitToStorageFn;
+  fetchFromStorage?: FetchFromStorageFn;
 }
 
 // ─── State Machine Types ───
@@ -158,6 +177,9 @@ export interface SendUpdateResponse extends AckResponse<{
   createdAt: number;
 }> {}
 
+// `cid`/`commitCid` above and below are the sync server's wire-format field
+// names for the commit's content reference; they carry whatever reference
+// `commitToStorage` returned, regardless of storage backend.
 export interface CommitResponse extends AckResponse<{
   cid: string;
   createdAt: number;


### PR DESCRIPTION
## What

Names and documents the storage-agnostic contract that `CollabServices` already has, instead of implying IPFS:

- Export `CommitToStorageFn` / `FetchFromStorageFn` types with docs stating the content reference is opaque to the sync engine — an IPFS CID, a Swarm reference, anything the host's storage returns — and is only ever round-tripped between the two functions.
- Rename `ipfsHash` locals to `contentRef` in `SyncManager` and drop "IPFS" from its error messages and comments ("Failed to upload commit to IPFS" fired for any backend).
- Rename the internal `FetchAbiParams.ipfsHash` to `abiRef` (not part of the public API, so no deprecation shim needed) and document `resolveAbi`'s reference as backend-agnostic.
- Pin the `resolveAbi` boundary with unit tests — the reference passes through verbatim and caching is per contract/chain/reference.

## Why

The public boundary is already pluggable — `commitToStorage(file) => Promise<string>` / `fetchFromStorage(ref)` — but the IPFS-shaped naming suggests otherwise to integrators. A host storing commits on a different backend (we run one on Ethereum Swarm) works today with zero code changes; this PR makes that a documented contract rather than an accident.

This is the counterpart of fileverse-ddoc's storage-agnostic props work, adapted to dsheets: ddoc needed a new prop surface and adapter for images, while dsheets' commit boundary was already agnostic in shape — so this is naming, documentation and tests only.

## Notes

- No behavior change. The sync server's wire-format fields (`cid`/`commitCid`) are untouched and documented as carrying whatever reference `commitToStorage` returned.
- Adds the repo's first vitest suite (3 tests, `npm run test:unit`).
- Verified: `tsc --noEmit` clean, tests pass, `vite build` clean.

A follow-up PR adds an optional pure-Swarm storage backend + demo built on this boundary.
