### PR TITLE
fix(xlsx-export): preserve background fill on empty cells

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fileverse-dev/dsheet",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fileverse-dev/dsheet",
-      "version": "4.1.1",
+      "version": "4.1.2",
       "dependencies": {
         "@fileverse-dev/dsheets-templates": "^0.0.31",
         "@fileverse-dev/formulajs": "4.4.54",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fileverse-dev/dsheet",
   "private": false,
   "description": "DSheet",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "main": "dist/index.es.js",
   "module": "dist/index.es.js",
   "exports": {

--- a/src/editor/utils/xlsx-export-impl.tsx
+++ b/src/editor/utils/xlsx-export-impl.tsx
@@ -401,6 +401,27 @@ export const handleExportToXLSX = async (
         applyBordersToWorksheet(worksheet, sheet.config.borderInfo);
       }
 
+      // STUB FORMAT-ONLY CELLS
+      // xlsx-js-style drops any cell that has no type `t` — so a styled but
+      // valueless cell (e.g. a black background on an empty cell)
+      // is written with no <c> element and loses
+      // its fill on export. Give such cells an empty-string type so the writer
+      // emits `<c .. t="str"><v></v></c>` and preserves the style.
+      Object.keys(worksheet).forEach((key) => {
+        if (key.startsWith('!')) return;
+        const cell = worksheet[key];
+        if (
+          cell &&
+          cell.s &&
+          cell.t == null &&
+          cell.v == null &&
+          cell.f == null
+        ) {
+          cell.t = 's';
+          cell.v = '';
+        }
+      });
+
       const subSheetName =
         sheet.name.length > 30 ? sheet.name.slice(0, 30) : sheet.name;
 


### PR DESCRIPTION
Empty cells with a background fill (from Google Sheets/Excel imports) were dropped on .xlsx export because xlsx-js-style skips cells with no type - turning colored blanks white. 

Fix: stub styled-but-valueless cells with an empty-string type before writing, so the fill is preserved through the import→export round-trip.